### PR TITLE
feat: add bot support for iw5

### DIFF
--- a/build.py
+++ b/build.py
@@ -5,6 +5,7 @@ import shutil
 # Configuration
 SOLUTION_FILE = "codxe.sln"
 MSBUILD_PATH = r"C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe"
+MSBUILD_ARGS = ["/m", "/p:BuildInParallel=true"]
 BINARY_PATH = r"build\Release\bin\codxe.xex"
 STAGING_DIR = r"build\staging"
 RESOURCES_PATH = r"resources"
@@ -43,7 +44,8 @@ with open(VERSION_HEADER_PATH, "w") as version_file:
     version_file.write("#pragma once\n\n")
     version_file.write(f"#define BUILD_NUMBER {BUILD_NUMBER}\n")
 
-result = subprocess.run([MSBUILD_PATH, SOLUTION_FILE])
+print("Building solution with parallel MSBuild jobs...")
+result = subprocess.run([MSBUILD_PATH, SOLUTION_FILE, *MSBUILD_ARGS])
 if result.returncode != 0:
     print("ERROR: Build failed.")
     exit(result.returncode)

--- a/codxe.vcxproj
+++ b/codxe.vcxproj
@@ -147,6 +147,7 @@
       <ClCompile Include="src\game\iw5\mp\main.cpp" />
       <ClCompile Include="src\game\iw5\mp\branding.cpp" />
       <ClCompile Include="src\game\iw5\mp\bots.cpp" />
+      <ClCompile Include="src\game\iw5\mp\events.cpp" />
       <ClCompile Include="src\game\iw5\mp\patches.cpp" />
       <ClCompile Include="src\game\iw5\mp\pm.cpp" />
       <ClCompile Include="src\game\iw5\mp\script.cpp" />

--- a/codxe.vcxproj
+++ b/codxe.vcxproj
@@ -146,6 +146,7 @@
 
       <ClCompile Include="src\game\iw5\mp\main.cpp" />
       <ClCompile Include="src\game\iw5\mp\branding.cpp" />
+      <ClCompile Include="src\game\iw5\mp\bots.cpp" />
       <ClCompile Include="src\game\iw5\mp\patches.cpp" />
       <ClCompile Include="src\game\iw5\mp\pm.cpp" />
       <ClCompile Include="src\game\iw5\mp\script.cpp" />

--- a/src/game/iw5/mp/bots.cpp
+++ b/src/game/iw5/mp/bots.cpp
@@ -126,8 +126,6 @@ namespace iw5
             SV_DirectConnect(botAddress, firstAvailableSlot - 1);
             SV_Cmd_EndTokenizedString();
 
-            // SV_DirectConnect processes the connection synchronously, so the
-            // client slot state is set by the time it returns. No polling needed.
             auto *clients = *svs_clients;
 
             if (!clients || clients[firstAvailableSlot].header.state < 1)

--- a/src/game/iw5/mp/bots.cpp
+++ b/src/game/iw5/mp/bots.cpp
@@ -126,29 +126,13 @@ namespace iw5
             SV_DirectConnect(botAddress, firstAvailableSlot - 1);
             SV_Cmd_EndTokenizedString();
 
-            // we need to ensure the slot is created before carrying on... maybe this should be around addbot instead?
+            // SV_DirectConnect processes the connection synchronously, so the
+            // client slot state is set by the time it returns. No polling needed.
             auto *clients = *svs_clients;
-            bool joined = false;
-            const int waitCycles = 100;
 
-            for (int t = 0; t < waitCycles; ++t)
+            if (!clients || clients[firstAvailableSlot].header.state < 1)
             {
-                if (!clients)
-                    break;
-
-                if (clients[firstAvailableSlot].header.state >= 1)
-                {
-                    joined = true;
-                    break;
-                }
-
-                Sleep(50);
-                clients = *svs_clients; // get latest pointer to clients
-            }
-
-            if (!joined)
-            {
-                DbgPrint("AddBot: client did not become active for slot %d, aborting\n", firstAvailableSlot);
+                DbgPrint("AddBot: client slot %d not active after SV_DirectConnect, aborting\n", firstAvailableSlot);
                 return;
             }
 

--- a/src/game/iw5/mp/bots.cpp
+++ b/src/game/iw5/mp/bots.cpp
@@ -3,205 +3,208 @@
 
 namespace iw5
 {
-    namespace mp
+namespace mp
+{
+dvar_t *sv_maxClients = nullptr;
+static dvar_t *ResolveSvMaxClients()
+{
+    if (sv_maxClients == nullptr)
     {
-        dvar_t *sv_maxClients = nullptr;
-        static dvar_t* ResolveSvMaxClients()
+        sv_maxClients = Dvar_FindMalleableVar("sv_maxclients");
+    }
+    return sv_maxClients;
+}
+
+static bool CanAddBot()
+{
+    auto count = 0;
+
+    ResolveSvMaxClients();
+
+    auto *clients = *svs_clients;
+
+    if (sv_maxClients == nullptr)
+    {
+        DbgPrint("CanAddBot: sv_maxClients dvar is null\n");
+        return false;
+    }
+
+    for (auto i = 0; i < sv_maxClients->current.integer; ++i)
+    {
+        client_t *client = &clients[i];
+
+        if (client->header.state >= 1)
         {
-            if (sv_maxClients == nullptr)
-            {
-                sv_maxClients = Dvar_FindMalleableVar("sv_maxclients");
-            }
-            return sv_maxClients;
+            ++count;
         }
+    }
 
-        static bool CanAddBot()
+    return count < sv_maxClients->current.integer;
+}
+
+static int GetAvailableClientSlot()
+{
+    auto *clients = *svs_clients;
+
+    if (sv_maxClients == nullptr)
+    {
+        DbgPrint("GetAvailableClientSlot: sv_maxClients is null\n");
+        return -1;
+    }
+
+    for (auto i = 1; i < sv_maxClients->current.integer; ++i)
+    {
+        client_t *client = &clients[i];
+        auto state = client->header.state;
+        if (state < 1)
         {
-            auto count = 0;
-
-            ResolveSvMaxClients();
-
-            auto *clients = *svs_clients;
-
-            if (sv_maxClients == nullptr)
-            {
-                DbgPrint("CanAddBot: sv_maxClients dvar is null\n");
-                return false;
-            }
-
-            for (auto i = 0; i < sv_maxClients->current.integer; ++i)
-            {
-                client_t *client = &clients[i];
-
-                if (client->header.state >= 1)
-                {
-                    ++count;
-                }
-            }
-
-            return count < sv_maxClients->current.integer;
+            return i;
         }
+    }
 
-        static int GetAvailableClientSlot()
-        {
-            auto *clients = *svs_clients;
+    return -1;
+}
 
-            if (sv_maxClients == nullptr)
-            {
-                DbgPrint("GetAvailableClientSlot: sv_maxClients is null\n");
-                return -1;
-            }
+static char *GetBotName(int slot)
+{
+    int id = slot >= 0 ? slot : *svs_numclients;
+    return va("Bot_%d", id);
+}
 
-            for (auto i = 1; i < sv_maxClients->current.integer; ++i)
-            {
-                client_t *client = &clients[i];
-                auto state = client->header.state;
-                if (state < 1)
-                {
-                    return i;
-                }
-            }
+static uint32_t SpawnBotThread(SpawnBotOptions *opts)
+{
+    Sleep(150);
 
-            return -1;
-        }
+    Scr_AddString("autoassign");
+    Scr_AddString("team_marinesopfor");
+    Scr_NotifyNum(opts->entNum, 0, SL_GetString("menuresponse", 0), 2);
 
-        static char* GetBotName(int slot)
-        {
-            int id = slot >= 0 ? slot : *svs_numclients;
-            return va("Bot_%d", id);
-        }
+    Sleep(200);
 
-        static uint32_t SpawnBotThread(SpawnBotOptions* opts)
-        {
-            Sleep(150);
+    Scr_AddString("class0");
+    Scr_AddString("changeclass");
+    Scr_NotifyNum(opts->entNum, 0, SL_GetString("menuresponse", 0), 2);
 
-            Scr_AddString("autoassign");
-            Scr_AddString("team_marinesopfor");
-            Scr_NotifyNum(opts->entNum, 0, SL_GetString("menuresponse", 0), 2);
+    auto ent = &g_entities[opts->entNum];
+    ent->client->sess.cs.rank = opts->level;
+    ent->client->sess.cs.prestige = opts->prestige;
 
-            Sleep(200);
+    delete opts;
 
-            Scr_AddString("class0");
-            Scr_AddString("changeclass");
-            Scr_NotifyNum(opts->entNum, 0, SL_GetString("menuresponse", 0), 2);
+    return 0;
+}
 
-            auto ent = &g_entities[opts->entNum];
-            ent->client->sess.cs.rank = opts->level;
-            ent->client->sess.cs.prestige = opts->prestige;
+static void AddBot()
+{
+    if (!CanAddBot())
+    {
+        DbgPrint("Cannot add bot, max clients reached\n");
+        return;
+    }
 
-            delete opts;
+    auto firstAvailableSlot = GetAvailableClientSlot();
 
-            return 0;
-        }
+    auto botName = GetBotName(firstAvailableSlot);
+    auto xuid1 = G_IRand(0, INT_MAX);
+    auto xuid2 = G_IRand(0, INT_MAX);
 
-        static void AddBot()
-        {
-            if (!CanAddBot())
-            {
-                DbgPrint("Cannot add bot, max clients reached\n");
-                return;
-            }
+    auto botLevel = G_IRand(0, 79);
+    auto botPrestige = G_IRand(0, 20);
 
-            auto firstAvailableSlot = GetAvailableClientSlot();
+    auto connectString =
+        va("connect bot%d "
+           "\"\\rate\\20000\\name\\%s\\natType\\1\\rank\\%d\\prestige\\%d\\ec_usingTag\\0\\ec_usingTitle\\0\\ec_"
+           "TitleBg\\0\\ec_"
+           "Level\\0\\ptd_prestige_black_ops\\0\\ptd_rank_black_ops\\0\\ptd_prestige_mw2\\0\\ptd_rank_"
+           "mw2\\0\\ptd_prestige_world_at_war\\0\\ptd_rank_world_at_war\\0\\ptd_prestige_mw\\0\\ptd_rank_"
+           "mw\\0\\protocol\\%i\\checksum\\%i\\challenge\\0\\statver\\26 "
+           "3648679816\\invited\\1\\xuid\\%08x%08x\\onlineStats\\0\\migrating\\0\"",
+           firstAvailableSlot - 1, botName, botLevel, botPrestige, GetProtocolVersion(), BG_NetDataChecksum(), xuid1,
+           xuid2);
 
-            auto botName = GetBotName(firstAvailableSlot);
-            auto xuid1 = G_IRand(0, INT_MAX);
-            auto xuid2 = G_IRand(0, INT_MAX);
+    netadr_t botAddress = {};
+    botAddress.type = NA_BOT;
 
-            auto botLevel = G_IRand(0, 79);
-            auto botPrestige = G_IRand(0, 20);
+    SV_Cmd_TokenizeString(connectString);
+    SV_DirectConnect(botAddress, firstAvailableSlot - 1);
+    SV_Cmd_EndTokenizedString();
 
-            auto connectString =
-                va("connect bot%d \"\\rate\\20000\\name\\%s\\natType\\1\\rank\\%d\\prestige\\%d\\ec_usingTag\\0\\ec_usingTitle\\0\\ec_TitleBg\\0\\ec_"
-                   "Level\\0\\ptd_prestige_black_ops\\0\\ptd_rank_black_ops\\0\\ptd_prestige_mw2\\0\\ptd_rank_"
-                   "mw2\\0\\ptd_prestige_world_at_war\\0\\ptd_rank_world_at_war\\0\\ptd_prestige_mw\\0\\ptd_rank_"
-                   "mw\\0\\protocol\\%i\\checksum\\%i\\challenge\\0\\statver\\26 "
-                   "3648679816\\invited\\1\\xuid\\%08x%08x\\onlineStats\\0\\migrating\\0\"",
-                   firstAvailableSlot - 1, botName, botLevel, botPrestige, GetProtocolVersion(), BG_NetDataChecksum(), xuid1, xuid2);
-                        
-            netadr_t botAddress = {};
-            botAddress.type = NA_BOT;
+    auto *clients = *svs_clients;
 
-            SV_Cmd_TokenizeString(connectString);
-            SV_DirectConnect(botAddress, firstAvailableSlot - 1);
-            SV_Cmd_EndTokenizedString();
+    if (!clients || clients[firstAvailableSlot].header.state < 1)
+    {
+        DbgPrint("AddBot: client slot %d not active after SV_DirectConnect, aborting\n", firstAvailableSlot);
+        return;
+    }
 
-            auto *clients = *svs_clients;
+    client_t *pClient = &clients[firstAvailableSlot];
+    pClient->scriptId = 1023;
+    pClient->bIsTestClient = 1;
 
-            if (!clients || clients[firstAvailableSlot].header.state < 1)
-            {
-                DbgPrint("AddBot: client slot %d not active after SV_DirectConnect, aborting\n", firstAvailableSlot);
-                return;
-            }
+    usercmd_s cmd = {};
+    SV_SendClientGameState(pClient);
+    SV_ClientEnterWorld(pClient, &cmd);
 
-            client_t *pClient = &clients[firstAvailableSlot];
-            pClient->scriptId = 1023;
-            pClient->bIsTestClient = 1;
+    SpawnBotOptions *botOpts = new SpawnBotOptions();
+    botOpts->entNum = pClient->gentity->s.number;
+    botOpts->level = botLevel;
+    botOpts->prestige = botPrestige;
 
-            usercmd_s cmd = {};
-            SV_SendClientGameState(pClient);
-            SV_ClientEnterWorld(pClient, &cmd);
+    CreateThread(nullptr, 0, reinterpret_cast<PTHREAD_START_ROUTINE>(SpawnBotThread), botOpts, 0, nullptr);
+}
 
-            SpawnBotOptions *botOpts = new SpawnBotOptions();
-            botOpts->entNum = pClient->gentity->s.number;
-            botOpts->level = botLevel;
-            botOpts->prestige = botPrestige;
+void SpawnBot(scr_entref_t entref)
+{
+    if (!CanAddBot())
+    {
+        DbgPrint("Cannot add bot, max clients reached\n");
+        return;
+    }
 
-            CreateThread(nullptr, 0, reinterpret_cast<PTHREAD_START_ROUTINE>(SpawnBotThread), botOpts, 0, nullptr);
-        }
-        
-        void SpawnBot(scr_entref_t entref)
-        {
-            if (!CanAddBot())
-            {
-                DbgPrint("Cannot add bot, max clients reached\n");
-                return;
-            }
+    if (GetAvailableClientSlot() == -1)
+    {
+        DbgPrint("Cannot add bot, no available client slots\n");
+        return;
+    }
 
-            if (GetAvailableClientSlot() == -1)
-            {
-                DbgPrint("Cannot add bot, no available client slots\n");
-                return;
-            }
+    auto count = 1;
 
-            auto count = 1;
+    auto numParams = Scr_GetNumParam();
 
-            auto numParams = Scr_GetNumParam();
+    if (numParams > 1)
+    {
+        count = Scr_GetInt(1);
+    }
 
-            if (numParams > 1)
-            {
-                count = Scr_GetInt(1);
-            }
+    auto numBots = min(count, (int)*svs_numclients);
 
-            auto numBots = min(count, (int)*svs_numclients);
+    DbgPrint("Spawning %d bot(s)\n", numBots);
 
-            DbgPrint("Spawning %d bot(s)\n", numBots);
+    for (auto i = 0; i < numBots; ++i)
+    {
+        // can this all happen too fast?
+        AddBot();
+    }
+}
 
-            for (auto i = 0; i < numBots; ++i)
-            {
-                // can this all happen too fast?
-                AddBot();
-            }
-        }
+Detour SV_DropClient_Detour;
+static void SV_DropClient_Hook(client_t *cl, const char *reason, bool tellThem)
+{
+    if (cl->bIsTestClient == 1)
+        return;
 
-        Detour SV_DropClient_Detour;
-        static void SV_DropClient_Hook(client_t *cl, const char *reason, bool tellThem)
-        {
-            if (cl->bIsTestClient == 1)
-                return;
+    SV_DropClient_Detour.GetOriginal<SV_DropClient_t>()(cl, reason, tellThem);
+}
 
-            SV_DropClient_Detour.GetOriginal<SV_DropClient_t>()(cl, reason, tellThem);
-        }
+Bots::Bots()
+{
+    SV_DropClient_Detour = Detour(SV_DropClient, SV_DropClient_Hook);
+    SV_DropClient_Detour.Install();
+}
 
-        Bots::Bots()
-        {
-            SV_DropClient_Detour = Detour(SV_DropClient, SV_DropClient_Hook);
-            SV_DropClient_Detour.Install();
-        }
-
-        Bots::~Bots()
-        {
-            SV_DropClient_Detour.Remove();
-        }
-    } // namespace mp
+Bots::~Bots()
+{
+    SV_DropClient_Detour.Remove();
+}
+} // namespace mp
 } // namespace iw5

--- a/src/game/iw5/mp/bots.cpp
+++ b/src/game/iw5/mp/bots.cpp
@@ -1,0 +1,225 @@
+#include "pch.h"
+#include "bots.h"
+
+namespace iw5
+{
+    namespace mp
+    {
+        dvar_t *sv_maxClients = nullptr;
+        static dvar_t* ResolveSvMaxClients()
+        {
+            if (sv_maxClients == nullptr)
+            {
+                sv_maxClients = Dvar_FindMalleableVar("sv_maxclients");
+            }
+            return sv_maxClients;
+        }
+
+        static bool CanAddBot()
+        {
+            auto count = 0;
+
+            ResolveSvMaxClients();
+
+            auto *clients = *svs_clients;
+
+            if (sv_maxClients == nullptr)
+            {
+                DbgPrint("CanAddBot: sv_maxClients dvar is null\n");
+                return false;
+            }
+
+            for (auto i = 0; i < sv_maxClients->current.integer; ++i)
+            {
+                client_t *client = &clients[i];
+
+                if (client->header.state >= 1)
+                {
+                    ++count;
+                }
+            }
+
+            return count < sv_maxClients->current.integer;
+        }
+
+        static int GetAvailableClientSlot()
+        {
+            auto *clients = *svs_clients;
+
+            if (sv_maxClients == nullptr)
+            {
+                DbgPrint("GetAvailableClientSlot: sv_maxClients is null\n");
+                return -1;
+            }
+
+            for (auto i = 1; i < sv_maxClients->current.integer; ++i)
+            {
+                client_t *client = &clients[i];
+                auto state = client->header.state;
+                if (state < 1)
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        static char* GetBotName(int slot)
+        {
+            int id = slot >= 0 ? slot : *svs_numclients;
+            return va("Bot_%d", id);
+        }
+
+        static uint32_t SpawnBotThread(SpawnBotOptions* opts)
+        {
+            Sleep(150);
+
+            Scr_AddString("autoassign");
+            Scr_AddString("team_marinesopfor");
+            Scr_NotifyNum(opts->entNum, 0, SL_GetString("menuresponse", 0), 2);
+
+            Sleep(200);
+
+            Scr_AddString("class0");
+            Scr_AddString("changeclass");
+            Scr_NotifyNum(opts->entNum, 0, SL_GetString("menuresponse", 0), 2);
+
+            auto ent = &g_entities[opts->entNum];
+            ent->client->sess.cs.rank = opts->level;
+            ent->client->sess.cs.prestige = opts->prestige;
+
+            delete opts;
+
+            return 0;
+        }
+
+        static void AddBot()
+        {
+            if (!CanAddBot())
+            {
+                DbgPrint("Cannot add bot, max clients reached\n");
+                return;
+            }
+
+            auto firstAvailableSlot = GetAvailableClientSlot();
+
+            auto botName = GetBotName(firstAvailableSlot);
+            auto xuid1 = G_IRand(0, INT_MAX);
+            auto xuid2 = G_IRand(0, INT_MAX);
+
+            auto botLevel = G_IRand(0, 79);
+            auto botPrestige = G_IRand(0, 20);
+
+            auto connectString =
+                va("connect bot%d \"\\rate\\20000\\name\\%s\\natType\\1\\rank\\%d\\prestige\\%d\\ec_usingTag\\0\\ec_usingTitle\\0\\ec_TitleBg\\0\\ec_"
+                   "Level\\0\\ptd_prestige_black_ops\\0\\ptd_rank_black_ops\\0\\ptd_prestige_mw2\\0\\ptd_rank_"
+                   "mw2\\0\\ptd_prestige_world_at_war\\0\\ptd_rank_world_at_war\\0\\ptd_prestige_mw\\0\\ptd_rank_"
+                   "mw\\0\\protocol\\%i\\checksum\\%i\\challenge\\0\\statver\\26 "
+                   "3648679816\\invited\\1\\xuid\\%08x%08x\\onlineStats\\0\\migrating\\0\"",
+                   firstAvailableSlot - 1, botName, botLevel, botPrestige, GetProtocolVersion(), BG_NetDataChecksum(), xuid1, xuid2);
+                        
+            netadr_t botAddress = {};
+            botAddress.type = NA_BOT;
+
+            SV_Cmd_TokenizeString(connectString);
+            SV_DirectConnect(botAddress, firstAvailableSlot - 1);
+            SV_Cmd_EndTokenizedString();
+
+            // we need to ensure the slot is created before carrying on... maybe this should be around addbot instead?
+            auto *clients = *svs_clients;
+            bool joined = false;
+            const int waitCycles = 100;
+
+            for (int t = 0; t < waitCycles; ++t)
+            {
+                if (!clients)
+                    break;
+
+                if (clients[firstAvailableSlot].header.state >= 1)
+                {
+                    joined = true;
+                    break;
+                }
+
+                Sleep(50);
+                clients = *svs_clients; // get latest pointer to clients
+            }
+
+            if (!joined)
+            {
+                DbgPrint("AddBot: client did not become active for slot %d, aborting\n", firstAvailableSlot);
+                return;
+            }
+
+            client_t *pClient = &clients[firstAvailableSlot];
+            pClient->scriptId = 1023;
+            pClient->bIsTestClient = 1;
+
+            usercmd_s cmd = {};
+            SV_SendClientGameState(pClient);
+            SV_ClientEnterWorld(pClient, &cmd);
+
+            SpawnBotOptions *botOpts = new SpawnBotOptions();
+            botOpts->entNum = pClient->gentity->s.number;
+            botOpts->level = botLevel;
+            botOpts->prestige = botPrestige;
+
+            CreateThread(nullptr, 0, reinterpret_cast<PTHREAD_START_ROUTINE>(SpawnBotThread), botOpts, 0, nullptr);
+        }
+        
+        void SpawnBot(scr_entref_t entref)
+        {
+            if (!CanAddBot())
+            {
+                DbgPrint("Cannot add bot, max clients reached\n");
+                return;
+            }
+
+            if (GetAvailableClientSlot() == -1)
+            {
+                DbgPrint("Cannot add bot, no available client slots\n");
+                return;
+            }
+
+            auto count = 1;
+
+            auto numParams = Scr_GetNumParam();
+
+            if (numParams > 1)
+            {
+                count = Scr_GetInt(1);
+            }
+
+            auto numBots = min(count, (int)*svs_numclients);
+
+            DbgPrint("Spawning %d bot(s)\n", numBots);
+
+            for (auto i = 0; i < numBots; ++i)
+            {
+                // can this all happen too fast?
+                AddBot();
+            }
+        }
+
+        Detour SV_DropClient_Detour;
+        static void SV_DropClient_Hook(client_t *cl, const char *reason, bool tellThem)
+        {
+            if (cl->bIsTestClient == 1)
+                return;
+
+            SV_DropClient_Detour.GetOriginal<SV_DropClient_t>()(cl, reason, tellThem);
+        }
+
+        Bots::Bots()
+        {
+            SV_DropClient_Detour = Detour(SV_DropClient, SV_DropClient_Hook);
+            SV_DropClient_Detour.Install();
+        }
+
+        Bots::~Bots()
+        {
+            SV_DropClient_Detour.Remove();
+        }
+    } // namespace mp
+} // namespace iw5

--- a/src/game/iw5/mp/bots.cpp
+++ b/src/game/iw5/mp/bots.cpp
@@ -145,12 +145,8 @@ gentity_s *AddTestClient(const char *requestedName)
 {
     client_t *clients = *svs_clients;
     const int maxClients = GetMaxClients();
-    DbgPrint("[codxe][IW5][Bots] AddTestClient begin: clients=%p maxClients=%d\n", clients, maxClients);
     if (!clients || maxClients <= 0)
-    {
-        DbgPrint("[codxe][IW5][Bots] AddTestClient abort: client array unavailable\n");
         return nullptr;
-    }
 
     int clientNum = 0;
     for (; clientNum < maxClients; ++clientNum)
@@ -160,12 +156,7 @@ gentity_s *AddTestClient(const char *requestedName)
     }
 
     if (clientNum == maxClients)
-    {
-        DbgPrint("[codxe][IW5][Bots] AddTestClient abort: no free client slot\n");
         return nullptr;
-    }
-
-    DbgPrint("[codxe][IW5][Bots] AddTestClient selected slot %d\n", clientNum);
 
     char botName[32];
     if (requestedName)
@@ -180,10 +171,7 @@ gentity_s *AddTestClient(const char *requestedName)
 
         botName[length] = '\0';
         if (!length)
-        {
-            DbgPrint("[codxe][IW5][Bots] AddTestClient abort: custom name is empty after sanitizing\n");
             return nullptr;
-        }
     }
     else
     {
@@ -207,40 +195,24 @@ gentity_s *AddTestClient(const char *requestedName)
     // NA_BOT connection as the first bot reconnecting.
     botAddress.localNetID = static_cast<netsrc_t>(NS_INVALID_NETSRC + clientNum + 1);
 
-    DbgPrint("[codxe][IW5][Bots] AddTestClient slot %d: tokenizing connect string (port=%u localNetID=%d)\n", clientNum,
-             botPort, botAddress.localNetID);
     SV_Cmd_TokenizeString(connectString);
-    DbgPrint("[codxe][IW5][Bots] AddTestClient slot %d: entering SV_DirectConnect\n", clientNum);
     SV_DirectConnect(botAddress);
-    DbgPrint("[codxe][IW5][Bots] AddTestClient slot %d: SV_DirectConnect returned\n", clientNum);
     SV_Cmd_EndTokenizedString();
 
     client_t *client = &clients[clientNum];
     if (client->header.state == CON_DISCONNECTED || !client->gentity)
-    {
-        DbgPrint("[codxe][IW5][Bots] AddTestClient slot %d abort: state=%d gentity=%p\n", clientNum,
-                 client->header.state, client->gentity);
         return nullptr;
-    }
-
-    DbgPrint("[codxe][IW5][Bots] AddTestClient slot %d connected: state=%d gentity=%p\n", clientNum,
-             client->header.state, client->gentity);
 
     client->scriptId = 1023;
     client->bIsTestClient = 1;
     client->gentity->s.number = clientNum;
 
     usercmd_s cmd = {};
-    DbgPrint("[codxe][IW5][Bots] AddTestClient slot %d: entering SV_SendClientGameState\n", clientNum);
     SV_SendClientGameState(client);
-    DbgPrint("[codxe][IW5][Bots] AddTestClient slot %d: entering SV_ClientEnterWorld\n", clientNum);
     SV_ClientEnterWorld(client, &cmd);
-    DbgPrint("[codxe][IW5][Bots] AddTestClient slot %d: SV_ClientEnterWorld returned state=%d\n", clientNum,
-             client->header.state);
 
     ZeroMemory(&g_botai[clientNum], sizeof(g_botai[clientNum]));
     g_botai[clientNum].meleeChargeEnt = ENTITYNUM_NONE;
-    DbgPrint("[codxe][IW5][Bots] AddTestClient complete: slot=%d entity=%d\n", clientNum, client->gentity->s.number);
     return client->gentity;
 }
 

--- a/src/game/iw5/mp/bots.cpp
+++ b/src/game/iw5/mp/bots.cpp
@@ -141,7 +141,7 @@ BotMovementInfo *GetBotInfo(scr_entref_t entref)
     return &g_botai[entref.entnum];
 }
 
-gentity_s *AddTestClient()
+gentity_s *AddTestClient(const char *requestedName)
 {
     client_t *clients = *svs_clients;
     const int maxClients = GetMaxClients();
@@ -167,14 +167,37 @@ gentity_s *AddTestClient()
 
     DbgPrint("[codxe][IW5][Bots] AddTestClient selected slot %d\n", clientNum);
 
+    char botName[32];
+    if (requestedName)
+    {
+        int length = 0;
+        for (int i = 0; requestedName[i] && length < static_cast<int>(sizeof(botName)) - 1; ++i)
+        {
+            const unsigned char character = static_cast<unsigned char>(requestedName[i]);
+            if (character >= 0x20 && character != '\\' && character != '"' && character != ';')
+                botName[length++] = requestedName[i];
+        }
+
+        botName[length] = '\0';
+        if (!length)
+        {
+            DbgPrint("[codxe][IW5][Bots] AddTestClient abort: custom name is empty after sanitizing\n");
+            return nullptr;
+        }
+    }
+    else
+    {
+        _snprintf_s(botName, sizeof(botName), _TRUNCATE, "Bot_%d", clientNum);
+    }
+
     const unsigned int botPort = g_botPort++;
     const int xuidHigh = G_IRand(0, INT_MAX);
     const int xuidLow = G_IRand(0, INT_MAX);
     const char *connectString =
         va("connect bot%u "
-           "\"snaps\\20\\rate\\5000\\name\\Bot_%d\\natType\\1\\protocol\\%i\\checksum\\%i\\challenge\\0\\statver\\26 "
+           "\"snaps\\20\\rate\\5000\\name\\%s\\natType\\1\\protocol\\%i\\checksum\\%i\\challenge\\0\\statver\\26 "
            "3648679816\\invited\\1\\xuid\\%08x%08x\\onlineStats\\0\\migrating\\0\\qport\\%u\"",
-           botPort, clientNum, GetProtocolVersion(), BG_NetDataChecksum(), xuidHigh, xuidLow, botPort);
+           botPort, botName, GetProtocolVersion(), BG_NetDataChecksum(), xuidHigh, xuidLow, botPort);
 
     netadr_t botAddress = {};
     botAddress.type = NA_BOT;
@@ -311,7 +334,14 @@ void ResetBotState()
 
 void GScr_AddTestClient()
 {
-    gentity_s *entity = AddTestClient();
+    if (Scr_GetNumParam() > 1)
+    {
+        Scr_ErrorInternal();
+        return;
+    }
+
+    const char *name = Scr_GetNumParam() == 1 ? Scr_GetString(0) : nullptr;
+    gentity_s *entity = AddTestClient(name);
     if (entity)
         Scr_AddEntityNum(entity->s.number, 0);
 }

--- a/src/game/iw5/mp/bots.cpp
+++ b/src/game/iw5/mp/bots.cpp
@@ -37,6 +37,7 @@ struct BotMovementInfo
 {
     bool active;
     int buttons;
+    Weapon weapon;
     bool hasMove;
     char forwardMove;
     char rightMove;
@@ -57,6 +58,16 @@ struct BotAction
 BotMovementInfo g_botai[IW5_MAX_CLIENTS];
 dvar_t *sv_maxClients = nullptr;
 unsigned int g_botPort = 0;
+
+Detour G_SelectWeapon_Detour;
+
+int *G_SelectWeapon_Hook(int clientNum, Weapon weapon)
+{
+    if (clientNum >= 0 && clientNum < IW5_MAX_CLIENTS)
+        g_botai[clientNum].weapon = weapon;
+
+    return G_SelectWeapon_Detour.GetOriginal<G_SelectWeapon_t>()(clientNum, weapon);
+}
 
 const BotAction BOT_ACTIONS[] = {
     {"gostand", CMD_BUTTON_UP},
@@ -240,12 +251,19 @@ void SV_ClientThink_Hook(client_t *client, usercmd_s *cmd)
         return;
     }
 
-    const BotMovementInfo &bot = g_botai[clientNum];
+    BotMovementInfo &bot = g_botai[clientNum];
     const playerState_s &ps = level->clients[clientNum].ps;
+
+    // The player's current weapon is temporarily cleared while mantling. A
+    // real client keeps sending its selected weapon in usercmd, so preserve
+    // the last non-empty selection for test clients as well.
+    if (ps.weapCommon.weapon.data != 0)
+        bot.weapon = ps.weapCommon.weapon;
+
     usercmd_s botCmd = {};
     botCmd.serverTime = cmd->serverTime;
     botCmd.buttons = bot.buttons;
-    botCmd.weapon = ps.weapCommon.weapon;
+    botCmd.weapon = bot.weapon.data != 0 ? bot.weapon : ps.weapCommon.weapon;
     botCmd.offHand = ps.weapCommon.offHand;
     botCmd.forwardmove = bot.hasMove ? bot.forwardMove : 0;
     botCmd.rightmove = bot.hasMove ? bot.rightMove : 0;
@@ -403,12 +421,16 @@ void PlayerCmd_BotAngles(scr_entref_t entref)
 Bots::Bots()
 {
     ResetBotState();
+    G_SelectWeapon_Detour = Detour(G_SelectWeapon, G_SelectWeapon_Hook);
+    G_SelectWeapon_Detour.Install();
+
     SV_ClientThink_Detour = Detour(SV_ClientThink, SV_ClientThink_Hook);
     SV_ClientThink_Detour.Install();
 }
 
 Bots::~Bots()
 {
+    G_SelectWeapon_Detour.Remove();
     SV_ClientThink_Detour.Remove();
     ResetBotState();
 }

--- a/src/game/iw5/mp/bots.cpp
+++ b/src/game/iw5/mp/bots.cpp
@@ -184,8 +184,8 @@ gentity_s *AddTestClient()
     // NA_BOT connection as the first bot reconnecting.
     botAddress.localNetID = static_cast<netsrc_t>(NS_INVALID_NETSRC + clientNum + 1);
 
-    DbgPrint("[codxe][IW5][Bots] AddTestClient slot %d: tokenizing connect string (port=%u localNetID=%d)\n",
-             clientNum, botPort, botAddress.localNetID);
+    DbgPrint("[codxe][IW5][Bots] AddTestClient slot %d: tokenizing connect string (port=%u localNetID=%d)\n", clientNum,
+             botPort, botAddress.localNetID);
     SV_Cmd_TokenizeString(connectString);
     DbgPrint("[codxe][IW5][Bots] AddTestClient slot %d: entering SV_DirectConnect\n", clientNum);
     SV_DirectConnect(botAddress);
@@ -217,8 +217,7 @@ gentity_s *AddTestClient()
 
     ZeroMemory(&g_botai[clientNum], sizeof(g_botai[clientNum]));
     g_botai[clientNum].meleeChargeEnt = ENTITYNUM_NONE;
-    DbgPrint("[codxe][IW5][Bots] AddTestClient complete: slot=%d entity=%d\n", clientNum,
-             client->gentity->s.number);
+    DbgPrint("[codxe][IW5][Bots] AddTestClient complete: slot=%d entity=%d\n", clientNum, client->gentity->s.number);
     return client->gentity;
 }
 

--- a/src/game/iw5/mp/bots.cpp
+++ b/src/game/iw5/mp/bots.cpp
@@ -222,6 +222,7 @@ gentity_s *AddTestClient()
 }
 
 Detour SV_ClientThink_Detour;
+Detour SV_CalcPings_Detour;
 
 void SV_ClientThink_Hook(client_t *client, usercmd_s *cmd)
 {
@@ -282,6 +283,22 @@ void SV_ClientThink_Hook(client_t *client, usercmd_s *cmd)
     }
 
     SV_ClientThink_Detour.GetOriginal<decltype(SV_ClientThink)>()(client, &botCmd);
+}
+
+void SV_CalcPings_Hook()
+{
+    SV_CalcPings_Detour.GetOriginal<decltype(SV_CalcPings)>()();
+
+    client_t *clients = *svs_clients;
+    const int maxClients = GetMaxClients();
+    if (!clients)
+        return;
+
+    for (int i = 0; i < maxClients; ++i)
+    {
+        if (clients[i].header.netchan.remoteAddress.type == NA_BOT)
+            clients[i].ping = 0;
+    }
 }
 } // namespace
 
@@ -425,12 +442,17 @@ Bots::Bots()
 
     SV_ClientThink_Detour = Detour(SV_ClientThink, SV_ClientThink_Hook);
     SV_ClientThink_Detour.Install();
+
+    // Test clients have no ping samples, so replace the stock 999 ping to show full connection bars.
+    SV_CalcPings_Detour = Detour(SV_CalcPings, SV_CalcPings_Hook);
+    SV_CalcPings_Detour.Install();
 }
 
 Bots::~Bots()
 {
     G_SelectWeapon_Detour.Remove();
     SV_ClientThink_Detour.Remove();
+    SV_CalcPings_Detour.Remove();
     ResetBotState();
 }
 } // namespace mp

--- a/src/game/iw5/mp/bots.cpp
+++ b/src/game/iw5/mp/bots.cpp
@@ -5,206 +5,412 @@ namespace iw5
 {
 namespace mp
 {
+namespace
+{
+const int IW5_MAX_CLIENTS = 18;
+const unsigned short ENTITYNUM_NONE = 2047;
+
+#define IW5_ANGLE2SHORT(x) ((int)((x) * 65536.0f / 360.0f) & 65535)
+
+enum CmdButton
+{
+    CMD_BUTTON_ATTACK = 1 << 0,
+    CMD_BUTTON_SPRINT = 1 << 1,
+    CMD_BUTTON_MELEE = 1 << 2,
+    CMD_BUTTON_ACTIVATE = 1 << 3,
+    CMD_BUTTON_RELOAD = 1 << 4,
+    CMD_BUTTON_USE_RELOAD = 1 << 5,
+    CMD_BUTTON_LEAN_LEFT = 1 << 6,
+    CMD_BUTTON_LEAN_RIGHT = 1 << 7,
+    CMD_BUTTON_PRONE = 1 << 8,
+    CMD_BUTTON_CROUCH = 1 << 9,
+    CMD_BUTTON_UP = 1 << 10,
+    CMD_BUTTON_ADS = 1 << 11,
+    CMD_BUTTON_BREATH = 1 << 13,
+    CMD_BUTTON_FRAG = 1 << 14,
+    CMD_BUTTON_OFFHAND_SECONDARY = 1 << 15,
+    CMD_BUTTON_THROW = 1 << 19,
+    CMD_BUTTON_REMOTE = 1 << 20,
+};
+
+struct BotMovementInfo
+{
+    bool active;
+    int buttons;
+    bool hasMove;
+    char forwardMove;
+    char rightMove;
+    bool hasAngles;
+    float angles[3];
+    bool hasRemoteAngles;
+    char remoteAngles[2];
+    unsigned short meleeChargeEnt;
+    unsigned char meleeChargeDist;
+};
+
+struct BotAction
+{
+    const char *name;
+    int button;
+};
+
+BotMovementInfo g_botai[IW5_MAX_CLIENTS];
 dvar_t *sv_maxClients = nullptr;
-static dvar_t *ResolveSvMaxClients()
+unsigned int g_botPort = 0;
+
+const BotAction BOT_ACTIONS[] = {
+    {"gostand", CMD_BUTTON_UP},
+    {"gocrouch", CMD_BUTTON_CROUCH},
+    {"goprone", CMD_BUTTON_PRONE},
+    {"fire", CMD_BUTTON_ATTACK},
+    {"attack", CMD_BUTTON_ATTACK},
+    {"melee", CMD_BUTTON_MELEE},
+    {"frag", CMD_BUTTON_FRAG},
+    {"smoke", CMD_BUTTON_OFFHAND_SECONDARY},
+    {"reload", CMD_BUTTON_RELOAD},
+    {"sprint", CMD_BUTTON_SPRINT},
+    {"leanleft", CMD_BUTTON_LEAN_LEFT},
+    {"leanright", CMD_BUTTON_LEAN_RIGHT},
+    {"ads", CMD_BUTTON_ADS | CMD_BUTTON_THROW},
+    {"speed_throw", CMD_BUTTON_ADS | CMD_BUTTON_THROW},
+    {"holdbreath", CMD_BUTTON_BREATH},
+    {"usereload", CMD_BUTTON_USE_RELOAD},
+    {"activate", CMD_BUTTON_ACTIVATE},
+    {"use", CMD_BUTTON_ACTIVATE},
+    {"remote", CMD_BUTTON_REMOTE},
+    {"crouch", CMD_BUTTON_CROUCH},
+    {"prone", CMD_BUTTON_PRONE},
+};
+
+char ClampMove(int value)
 {
-    if (sv_maxClients == nullptr)
-    {
+    if (value < -127)
+        return -127;
+    if (value > 127)
+        return 127;
+    return static_cast<char>(value);
+}
+
+unsigned char ClampByte(int value)
+{
+    if (value < 0)
+        return 0;
+    if (value > 255)
+        return 255;
+    return static_cast<unsigned char>(value);
+}
+
+unsigned short ClampEntityNum(int value)
+{
+    if (value < 0 || value > ENTITYNUM_NONE)
+        return ENTITYNUM_NONE;
+    return static_cast<unsigned short>(value);
+}
+
+int GetMaxClients()
+{
+    if (!sv_maxClients)
         sv_maxClients = Dvar_FindMalleableVar("sv_maxclients");
-    }
-    return sv_maxClients;
+
+    if (!sv_maxClients)
+        return 0;
+
+    const int maxClients = sv_maxClients->current.integer;
+    return maxClients < IW5_MAX_CLIENTS ? maxClients : IW5_MAX_CLIENTS;
 }
 
-static bool CanAddBot()
+BotMovementInfo *GetBotInfo(scr_entref_t entref)
 {
-    auto count = 0;
-
-    ResolveSvMaxClients();
-
-    auto *clients = *svs_clients;
-
-    if (sv_maxClients == nullptr)
+    if (entref.classnum != 0 || entref.entnum >= IW5_MAX_CLIENTS || !g_entities[entref.entnum].client)
     {
-        DbgPrint("CanAddBot: sv_maxClients dvar is null\n");
-        return false;
+        Scr_ErrorInternal();
+        return nullptr;
     }
 
-    for (auto i = 0; i < sv_maxClients->current.integer; ++i)
-    {
-        client_t *client = &clients[i];
-
-        if (client->header.state >= 1)
-        {
-            ++count;
-        }
-    }
-
-    return count < sv_maxClients->current.integer;
+    return &g_botai[entref.entnum];
 }
 
-static int GetAvailableClientSlot()
+gentity_s *AddTestClient()
 {
-    auto *clients = *svs_clients;
-
-    if (sv_maxClients == nullptr)
+    client_t *clients = *svs_clients;
+    const int maxClients = GetMaxClients();
+    DbgPrint("[codxe][IW5][Bots] AddTestClient begin: clients=%p maxClients=%d\n", clients, maxClients);
+    if (!clients || maxClients <= 0)
     {
-        DbgPrint("GetAvailableClientSlot: sv_maxClients is null\n");
-        return -1;
+        DbgPrint("[codxe][IW5][Bots] AddTestClient abort: client array unavailable\n");
+        return nullptr;
     }
 
-    for (auto i = 1; i < sv_maxClients->current.integer; ++i)
+    int clientNum = 0;
+    for (; clientNum < maxClients; ++clientNum)
     {
-        client_t *client = &clients[i];
-        auto state = client->header.state;
-        if (state < 1)
-        {
-            return i;
-        }
+        if (clients[clientNum].header.state == CON_DISCONNECTED)
+            break;
     }
 
-    return -1;
-}
-
-static char *GetBotName(int slot)
-{
-    int id = slot >= 0 ? slot : *svs_numclients;
-    return va("Bot_%d", id);
-}
-
-static uint32_t SpawnBotThread(SpawnBotOptions *opts)
-{
-    Sleep(150);
-
-    Scr_AddString("autoassign");
-    Scr_AddString("team_marinesopfor");
-    Scr_NotifyNum(opts->entNum, 0, SL_GetString("menuresponse", 0), 2);
-
-    Sleep(200);
-
-    Scr_AddString("class0");
-    Scr_AddString("changeclass");
-    Scr_NotifyNum(opts->entNum, 0, SL_GetString("menuresponse", 0), 2);
-
-    auto ent = &g_entities[opts->entNum];
-    ent->client->sess.cs.rank = opts->level;
-    ent->client->sess.cs.prestige = opts->prestige;
-
-    delete opts;
-
-    return 0;
-}
-
-static void AddBot()
-{
-    if (!CanAddBot())
+    if (clientNum == maxClients)
     {
-        DbgPrint("Cannot add bot, max clients reached\n");
-        return;
+        DbgPrint("[codxe][IW5][Bots] AddTestClient abort: no free client slot\n");
+        return nullptr;
     }
 
-    auto firstAvailableSlot = GetAvailableClientSlot();
+    DbgPrint("[codxe][IW5][Bots] AddTestClient selected slot %d\n", clientNum);
 
-    auto botName = GetBotName(firstAvailableSlot);
-    auto xuid1 = G_IRand(0, INT_MAX);
-    auto xuid2 = G_IRand(0, INT_MAX);
-
-    auto botLevel = G_IRand(0, 79);
-    auto botPrestige = G_IRand(0, 20);
-
-    auto connectString =
-        va("connect bot%d "
-           "\"\\rate\\20000\\name\\%s\\natType\\1\\rank\\%d\\prestige\\%d\\ec_usingTag\\0\\ec_usingTitle\\0\\ec_"
-           "TitleBg\\0\\ec_"
-           "Level\\0\\ptd_prestige_black_ops\\0\\ptd_rank_black_ops\\0\\ptd_prestige_mw2\\0\\ptd_rank_"
-           "mw2\\0\\ptd_prestige_world_at_war\\0\\ptd_rank_world_at_war\\0\\ptd_prestige_mw\\0\\ptd_rank_"
-           "mw\\0\\protocol\\%i\\checksum\\%i\\challenge\\0\\statver\\26 "
-           "3648679816\\invited\\1\\xuid\\%08x%08x\\onlineStats\\0\\migrating\\0\"",
-           firstAvailableSlot - 1, botName, botLevel, botPrestige, GetProtocolVersion(), BG_NetDataChecksum(), xuid1,
-           xuid2);
+    const unsigned int botPort = g_botPort++;
+    const int xuidHigh = G_IRand(0, INT_MAX);
+    const int xuidLow = G_IRand(0, INT_MAX);
+    const char *connectString =
+        va("connect bot%u "
+           "\"snaps\\20\\rate\\5000\\name\\Bot_%d\\natType\\1\\protocol\\%i\\checksum\\%i\\challenge\\0\\statver\\26 "
+           "3648679816\\invited\\1\\xuid\\%08x%08x\\onlineStats\\0\\migrating\\0\\qport\\%u\"",
+           botPort, clientNum, GetProtocolVersion(), BG_NetDataChecksum(), xuidHigh, xuidLow, botPort);
 
     netadr_t botAddress = {};
     botAddress.type = NA_BOT;
+    botAddress.port = static_cast<unsigned short>(botPort);
+    // IW5 ignores the port when comparing non-IP addresses. Give each bot a
+    // distinct localNetID so Party_FindFirstMemberAtAddr does not treat every
+    // NA_BOT connection as the first bot reconnecting.
+    botAddress.localNetID = static_cast<netsrc_t>(NS_INVALID_NETSRC + clientNum + 1);
 
+    DbgPrint("[codxe][IW5][Bots] AddTestClient slot %d: tokenizing connect string (port=%u localNetID=%d)\n",
+             clientNum, botPort, botAddress.localNetID);
     SV_Cmd_TokenizeString(connectString);
-    SV_DirectConnect(botAddress, firstAvailableSlot - 1);
+    DbgPrint("[codxe][IW5][Bots] AddTestClient slot %d: entering SV_DirectConnect\n", clientNum);
+    SV_DirectConnect(botAddress);
+    DbgPrint("[codxe][IW5][Bots] AddTestClient slot %d: SV_DirectConnect returned\n", clientNum);
     SV_Cmd_EndTokenizedString();
 
-    auto *clients = *svs_clients;
-
-    if (!clients || clients[firstAvailableSlot].header.state < 1)
+    client_t *client = &clients[clientNum];
+    if (client->header.state == CON_DISCONNECTED || !client->gentity)
     {
-        DbgPrint("AddBot: client slot %d not active after SV_DirectConnect, aborting\n", firstAvailableSlot);
-        return;
+        DbgPrint("[codxe][IW5][Bots] AddTestClient slot %d abort: state=%d gentity=%p\n", clientNum,
+                 client->header.state, client->gentity);
+        return nullptr;
     }
 
-    client_t *pClient = &clients[firstAvailableSlot];
-    pClient->scriptId = 1023;
-    pClient->bIsTestClient = 1;
+    DbgPrint("[codxe][IW5][Bots] AddTestClient slot %d connected: state=%d gentity=%p\n", clientNum,
+             client->header.state, client->gentity);
+
+    client->scriptId = 1023;
+    client->bIsTestClient = 1;
+    client->gentity->s.number = clientNum;
 
     usercmd_s cmd = {};
-    SV_SendClientGameState(pClient);
-    SV_ClientEnterWorld(pClient, &cmd);
+    DbgPrint("[codxe][IW5][Bots] AddTestClient slot %d: entering SV_SendClientGameState\n", clientNum);
+    SV_SendClientGameState(client);
+    DbgPrint("[codxe][IW5][Bots] AddTestClient slot %d: entering SV_ClientEnterWorld\n", clientNum);
+    SV_ClientEnterWorld(client, &cmd);
+    DbgPrint("[codxe][IW5][Bots] AddTestClient slot %d: SV_ClientEnterWorld returned state=%d\n", clientNum,
+             client->header.state);
 
-    SpawnBotOptions *botOpts = new SpawnBotOptions();
-    botOpts->entNum = pClient->gentity->s.number;
-    botOpts->level = botLevel;
-    botOpts->prestige = botPrestige;
-
-    CreateThread(nullptr, 0, reinterpret_cast<PTHREAD_START_ROUTINE>(SpawnBotThread), botOpts, 0, nullptr);
+    ZeroMemory(&g_botai[clientNum], sizeof(g_botai[clientNum]));
+    g_botai[clientNum].meleeChargeEnt = ENTITYNUM_NONE;
+    DbgPrint("[codxe][IW5][Bots] AddTestClient complete: slot=%d entity=%d\n", clientNum,
+             client->gentity->s.number);
+    return client->gentity;
 }
 
-void SpawnBot(scr_entref_t entref)
+Detour SV_ClientThink_Detour;
+
+void SV_ClientThink_Hook(client_t *client, usercmd_s *cmd)
 {
-    if (!CanAddBot())
+    // IW5's normal SV_UpdateBots path builds its usercmd inline, so SV_BotUserMove is not a reliable control seam.
+    client_t *clients = *svs_clients;
+    if (!client || !cmd || !clients)
     {
-        DbgPrint("Cannot add bot, max clients reached\n");
+        SV_ClientThink_Detour.GetOriginal<decltype(SV_ClientThink)>()(client, cmd);
         return;
     }
 
-    if (GetAvailableClientSlot() == -1)
+    const int clientNum = client - clients;
+    if (clientNum < 0 || clientNum >= GetMaxClients() || client->header.netchan.remoteAddress.type != NA_BOT)
     {
-        DbgPrint("Cannot add bot, no available client slots\n");
+        SV_ClientThink_Detour.GetOriginal<decltype(SV_ClientThink)>()(client, cmd);
         return;
     }
 
-    auto count = 1;
-
-    auto numParams = Scr_GetNumParam();
-
-    if (numParams > 1)
+    // Test clients do not send network packets back to the server, so they
+    // never acknowledge reliable server commands through the normal path.
+    client->reliableAcknowledge = client->reliableSequence;
+    client->lastPacketTime = cmd->serverTime;
+    if (!g_botai[clientNum].active)
     {
-        count = Scr_GetInt(1);
+        SV_ClientThink_Detour.GetOriginal<decltype(SV_ClientThink)>()(client, cmd);
+        return;
     }
 
-    auto numBots = min(count, (int)*svs_numclients);
+    const BotMovementInfo &bot = g_botai[clientNum];
+    const playerState_s &ps = level->clients[clientNum].ps;
+    usercmd_s botCmd = {};
+    botCmd.serverTime = cmd->serverTime;
+    botCmd.buttons = bot.buttons;
+    botCmd.weapon = ps.weapCommon.weapon;
+    botCmd.offHand = ps.weapCommon.offHand;
+    botCmd.forwardmove = bot.hasMove ? bot.forwardMove : 0;
+    botCmd.rightmove = bot.hasMove ? bot.rightMove : 0;
+    botCmd.meleeChargeEnt = bot.meleeChargeEnt;
+    botCmd.meleeChargeDist = bot.meleeChargeDist;
 
-    DbgPrint("Spawning %d bot(s)\n", numBots);
-
-    for (auto i = 0; i < numBots; ++i)
+    if (bot.hasAngles)
     {
-        // can this all happen too fast?
-        AddBot();
+        for (int i = 0; i < 3; ++i)
+            botCmd.angles[i] = IW5_ANGLE2SHORT(bot.angles[i] - ps.delta_angles[i]);
     }
+
+    if (bot.hasRemoteAngles)
+    {
+        botCmd.remoteControlAngles[0] = bot.remoteAngles[0];
+        botCmd.remoteControlAngles[1] = bot.remoteAngles[1];
+    }
+
+    SV_ClientThink_Detour.GetOriginal<decltype(SV_ClientThink)>()(client, &botCmd);
+}
+} // namespace
+
+void ResetBotState()
+{
+    ZeroMemory(g_botai, sizeof(g_botai));
+    for (int i = 0; i < IW5_MAX_CLIENTS; ++i)
+        g_botai[i].meleeChargeEnt = ENTITYNUM_NONE;
 }
 
-Detour SV_DropClient_Detour;
-static void SV_DropClient_Hook(client_t *cl, const char *reason, bool tellThem)
+void GScr_AddTestClient()
 {
-    if (cl->bIsTestClient == 1)
-        return;
+    gentity_s *entity = AddTestClient();
+    if (entity)
+        Scr_AddEntityNum(entity->s.number, 0);
+}
 
-    SV_DropClient_Detour.GetOriginal<SV_DropClient_t>()(cl, reason, tellThem);
+void PlayerCmd_BotAction(scr_entref_t entref)
+{
+    // Parameter 0 is the selector consumed by the getviewmodel trampoline.
+    BotMovementInfo *bot = GetBotInfo(entref);
+    if (!bot || Scr_GetNumParam() != 2)
+    {
+        Scr_ErrorInternal();
+        return;
+    }
+
+    const char *action = Scr_GetString(1);
+    if (!action || (action[0] != '+' && action[0] != '-'))
+    {
+        Scr_ErrorInternal();
+        return;
+    }
+
+    for (size_t i = 0; i < ARRAYSIZE(BOT_ACTIONS); ++i)
+    {
+        if (_stricmp(&action[1], BOT_ACTIONS[i].name) == 0)
+        {
+            if (action[0] == '+')
+                bot->buttons |= BOT_ACTIONS[i].button;
+            else
+                bot->buttons &= ~BOT_ACTIONS[i].button;
+
+            bot->active = true;
+            return;
+        }
+    }
+
+    Scr_ErrorInternal();
+}
+
+void PlayerCmd_BotStop(scr_entref_t entref)
+{
+    BotMovementInfo *bot = GetBotInfo(entref);
+    if (!bot || Scr_GetNumParam() != 1)
+    {
+        Scr_ErrorInternal();
+        return;
+    }
+
+    bot->buttons = 0;
+    bot->active = true;
+    bot->hasMove = false;
+    bot->hasRemoteAngles = false;
+    bot->meleeChargeEnt = ENTITYNUM_NONE;
+    bot->meleeChargeDist = 0;
+
+    const playerState_s &ps = level->clients[entref.entnum].ps;
+    for (int i = 0; i < 3; ++i)
+        bot->angles[i] = ps.viewangles[i];
+}
+
+void PlayerCmd_BotMovement(scr_entref_t entref)
+{
+    BotMovementInfo *bot = GetBotInfo(entref);
+    if (!bot || Scr_GetNumParam() != 3)
+    {
+        Scr_ErrorInternal();
+        return;
+    }
+
+    const int forwardMove = Scr_GetInt(1);
+    const int rightMove = Scr_GetInt(2);
+
+    bot->forwardMove = ClampMove(forwardMove);
+    bot->rightMove = ClampMove(rightMove);
+    bot->active = true;
+    bot->hasMove = true;
+}
+
+void PlayerCmd_BotMeleeParams(scr_entref_t entref)
+{
+    BotMovementInfo *bot = GetBotInfo(entref);
+    if (!bot || Scr_GetNumParam() != 3)
+    {
+        Scr_ErrorInternal();
+        return;
+    }
+
+    bot->meleeChargeEnt = ClampEntityNum(Scr_GetInt(1));
+    bot->meleeChargeDist = ClampByte(static_cast<int>(Scr_GetFloat(2)));
+    bot->active = true;
+}
+
+void PlayerCmd_BotRemoteAngles(scr_entref_t entref)
+{
+    BotMovementInfo *bot = GetBotInfo(entref);
+    if (!bot || Scr_GetNumParam() != 3)
+    {
+        Scr_ErrorInternal();
+        return;
+    }
+
+    bot->remoteAngles[0] = ClampMove(static_cast<int>(Scr_GetFloat(1)));
+    bot->remoteAngles[1] = ClampMove(static_cast<int>(Scr_GetFloat(2)));
+    bot->active = true;
+    bot->hasRemoteAngles = true;
+}
+
+void PlayerCmd_BotAngles(scr_entref_t entref)
+{
+    BotMovementInfo *bot = GetBotInfo(entref);
+    if (!bot || Scr_GetNumParam() != 4)
+    {
+        Scr_ErrorInternal();
+        return;
+    }
+
+    for (int i = 0; i < 3; ++i)
+        bot->angles[i] = Scr_GetFloat(i + 1);
+
+    bot->active = true;
+    bot->hasAngles = true;
 }
 
 Bots::Bots()
 {
-    SV_DropClient_Detour = Detour(SV_DropClient, SV_DropClient_Hook);
-    SV_DropClient_Detour.Install();
+    ResetBotState();
+    SV_ClientThink_Detour = Detour(SV_ClientThink, SV_ClientThink_Hook);
+    SV_ClientThink_Detour.Install();
 }
 
 Bots::~Bots()
 {
-    SV_DropClient_Detour.Remove();
+    SV_ClientThink_Detour.Remove();
+    ResetBotState();
 }
 } // namespace mp
 } // namespace iw5

--- a/src/game/iw5/mp/bots.h
+++ b/src/game/iw5/mp/bots.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "pch.h"
+namespace iw5
+{
+namespace mp
+{
+
+    void SpawnBot(scr_entref_t entref);
+
+    class Bots : public Module
+    {
+      public:
+        Bots();
+        ~Bots();
+    };
+} // namespace mp
+} // namespace iw5

--- a/src/game/iw5/mp/bots.h
+++ b/src/game/iw5/mp/bots.h
@@ -6,13 +6,19 @@ namespace iw5
 namespace mp
 {
 
-    void SpawnBot(scr_entref_t entref);
-
-    class Bots : public Module
-    {
-      public:
-        Bots();
-        ~Bots();
-    };
+void GScr_AddTestClient();
+void ResetBotState();
+void PlayerCmd_BotAction(scr_entref_t entref);
+void PlayerCmd_BotStop(scr_entref_t entref);
+void PlayerCmd_BotMovement(scr_entref_t entref);
+void PlayerCmd_BotMeleeParams(scr_entref_t entref);
+void PlayerCmd_BotRemoteAngles(scr_entref_t entref);
+void PlayerCmd_BotAngles(scr_entref_t entref);
+class Bots : public Module
+{
+  public:
+    Bots();
+    ~Bots();
+};
 } // namespace mp
 } // namespace iw5

--- a/src/game/iw5/mp/events.cpp
+++ b/src/game/iw5/mp/events.cpp
@@ -1,0 +1,40 @@
+#include "pch.h"
+#include "events.h"
+
+namespace iw5
+{
+namespace mp
+{
+
+std::vector<std::function<void(bool)>> Events::vm_shutdown_callbacks;
+Detour Events::G_ShutdownGame_Detour;
+
+void Events::G_ShutdownGame_Hook(int freeScripts)
+{
+    G_ShutdownGame_Detour.GetOriginal<G_ShutdownGame_t>()(freeScripts);
+
+    for (auto it = vm_shutdown_callbacks.begin(); it != vm_shutdown_callbacks.end(); ++it)
+    {
+        (*it)(freeScripts != 0);
+    }
+}
+
+void Events::OnVMShutdown(const std::function<void(bool)> &callback)
+{
+    vm_shutdown_callbacks.emplace_back(callback);
+}
+
+Events::Events()
+{
+    G_ShutdownGame_Detour = Detour(G_ShutdownGame, G_ShutdownGame_Hook);
+    G_ShutdownGame_Detour.Install();
+}
+
+Events::~Events()
+{
+    G_ShutdownGame_Detour.Remove();
+    vm_shutdown_callbacks.clear();
+}
+
+} // namespace mp
+} // namespace iw5

--- a/src/game/iw5/mp/events.h
+++ b/src/game/iw5/mp/events.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "pch.h"
+
+namespace iw5
+{
+namespace mp
+{
+class Events : public Module
+{
+  public:
+    Events();
+    ~Events();
+
+    const char *get_name() override
+    {
+        return "Events";
+    };
+
+    static void OnVMShutdown(const std::function<void(bool)> &callback);
+
+  private:
+    static std::vector<std::function<void(bool)>> vm_shutdown_callbacks;
+    static Detour G_ShutdownGame_Detour;
+    static void G_ShutdownGame_Hook(int freeScripts);
+};
+} // namespace mp
+} // namespace iw5

--- a/src/game/iw5/mp/main.cpp
+++ b/src/game/iw5/mp/main.cpp
@@ -4,6 +4,7 @@
 #include "patches.h"
 #include "pm.h"
 #include "script.h"
+#include "bots.h"
 
 namespace iw5
 {
@@ -205,6 +206,7 @@ IW5_MP_Plugin::IW5_MP_Plugin()
     RegisterModule(new patches());
     RegisterModule(new PlayerMovement());
     RegisterModule(new Script());
+    RegisterModule(new Bots());
 
     DB_FindXAssetHeader_Detour = Detour(DB_FindXAssetHeader, DB_FindXAssetHeader_Hook);
     DB_FindXAssetHeader_Detour.Install();

--- a/src/game/iw5/mp/main.cpp
+++ b/src/game/iw5/mp/main.cpp
@@ -13,9 +13,66 @@ namespace mp
 
 std::set<std::string> g_loaded_scripts;
 
+const unsigned int GSC_BYTECODE_ARENA_SIZE = 256 * 1024;
+unsigned __int8 *g_gsc_bytecode_arena = nullptr;
+unsigned int g_gsc_bytecode_arena_used = 0;
+
+unsigned __int8 *AllocateGSCBytecode(unsigned int size)
+{
+    if (!g_gsc_bytecode_arena)
+    {
+        const bool is_xenia = xbox::GetEnvironment() == xbox::ENVIRONMENT_XENIA;
+        g_gsc_bytecode_arena = PMem_AllocFromSource_NoDebug(GSC_BYTECODE_ARENA_SIZE, 4,
+                                                            // 0 crashes on hardware, 2 crashes on Xenia.
+                                                            is_xenia ? 0 : 2, PMEM_SOURCE_SCRIPT);
+        DbgPrint("[codxe][IW5][GSCLoader] bytecode arena=[%p, %p)\n", g_gsc_bytecode_arena,
+                 g_gsc_bytecode_arena + GSC_BYTECODE_ARENA_SIZE);
+    }
+
+    const unsigned int offset = (g_gsc_bytecode_arena_used + 3) & ~3u;
+    if (offset > GSC_BYTECODE_ARENA_SIZE || size > GSC_BYTECODE_ARENA_SIZE - offset)
+    {
+        DbgPrint("[codxe][IW5][GSCLoader] bytecode arena exhausted: requested=%u used=%u capacity=%u\n", size,
+                 g_gsc_bytecode_arena_used, GSC_BYTECODE_ARENA_SIZE);
+        return nullptr;
+    }
+
+    unsigned __int8 *bytecode = g_gsc_bytecode_arena + offset;
+    g_gsc_bytecode_arena_used = offset + size;
+    return bytecode;
+}
+
 bool ContainsScript(const std::string &name)
 {
     return g_loaded_scripts.find(name) != g_loaded_scripts.end();
+}
+
+bool ShouldLoadWaypointScript(const char *name)
+{
+    std::string scriptName = name ? name : "";
+    std::replace(scriptName.begin(), scriptName.end(), '\\', '/');
+
+    const std::string waypointPrefix = "scripts/mp/mp_";
+    if (scriptName.compare(0, waypointPrefix.size(), waypointPrefix) != 0)
+        return true;
+
+    const size_t fileNameOffset = scriptName.find('/', waypointPrefix.size());
+    if (fileNameOffset == std::string::npos || scriptName.compare(fileNameOffset + 1, 4, "wps_") != 0)
+        return true;
+
+    const dvar_t *mapname = Dvar_FindMalleableVar("mapname");
+    if (!mapname || !mapname->current.string || !mapname->current.string[0])
+    {
+        DbgPrint("[codxe][IW5][GSCLoader] skipping waypoint '%s': mapname is unavailable\n", name);
+        return false;
+    }
+
+    const std::string currentMapPrefix = std::string("scripts/mp/") + mapname->current.string + "/";
+    const bool shouldLoad = scriptName.compare(0, currentMapPrefix.size(), currentMapPrefix) == 0;
+    if (!shouldLoad)
+        DbgPrint("[codxe][IW5][GSCLoader] skipping waypoint '%s' for map '%s'\n", name, mapname->current.string);
+
+    return shouldLoad;
 }
 
 // Swap byte order for 32-bit integers
@@ -140,6 +197,9 @@ XAssetHeader *DB_FindXAssetHeader_Hook(XAssetType type, const char *name, int al
 {
     if (type == ASSET_TYPE_SCRIPTFILE)
     {
+        if (!ShouldLoadWaypointScript(name))
+            return DB_FindXAssetHeader_Detour.GetOriginal<DB_FindXAssetHeader_t>()(type, name, allowCreateDefault);
+
         std::string modBasePath = Config::GetModBasePath();
         std::string overridePath = modBasePath + "\\" + name + ".gscbin";
         std::replace(overridePath.begin(), overridePath.end(), '/', '\\');
@@ -153,9 +213,12 @@ XAssetHeader *DB_FindXAssetHeader_Hook(XAssetType type, const char *name, int al
             }
             else
             {
-                // Create a new
-                ScriptFile *scriptfile =
-                    (ScriptFile *)PMem_AllocFromSource_NoDebug(sizeof(ScriptFile), 4, 0, PMEM_SOURCE_SCRIPT);
+                DbgPrint("[codxe][IW5][GSCLoader] loading '%s': compressed=%u bytecode=%u total=%u\n", name,
+                         gscbin.compressedLen, gscbin.bytecodeLen, gscbin.compressedLen + gscbin.bytecodeLen);
+
+                // ProcessScript treats these as persistent writable data. Keeping them on the heap avoids
+                // consuming a 64 KiB script page for each small allocation.
+                ScriptFile *scriptfile = static_cast<ScriptFile *>(malloc(sizeof(ScriptFile)));
                 memset(scriptfile, 0, sizeof(ScriptFile));
 
                 scriptfile->name = name;
@@ -163,19 +226,25 @@ XAssetHeader *DB_FindXAssetHeader_Hook(XAssetType type, const char *name, int al
                 scriptfile->len = gscbin.len;
                 scriptfile->bytecodeLen = gscbin.bytecodeLen;
 
-                char *buffer = (char *)PMem_AllocFromSource_NoDebug(gscbin.buffer.size(), 4, 0, PMEM_SOURCE_SCRIPT);
+                char *buffer = static_cast<char *>(malloc(gscbin.buffer.size()));
                 memcpy(buffer, gscbin.buffer.data(), gscbin.buffer.size());
                 scriptfile->buffer = buffer;
 
-                const bool is_xenia = xbox::GetEnvironment() == xbox::ENVIRONMENT_XENIA;
-                unsigned __int8 *bytecode = PMem_AllocFromSource_NoDebug(gscbin.bytecode.size(), 4,
-                                                                         // 0 Crashes on hardware, 2 crashes on Xenia
-                                                                         // Don't know why, but this works around it
-                                                                         is_xenia ? 0 : 2, PMEM_SOURCE_SCRIPT);
+                unsigned __int8 *bytecode = AllocateGSCBytecode(gscbin.bytecodeLen);
+                if (!bytecode)
+                {
+                    free(buffer);
+                    free(scriptfile);
+                    return DB_FindXAssetHeader_Detour.GetOriginal<DB_FindXAssetHeader_t>()(type, name,
+                                                                                          allowCreateDefault);
+                }
                 memcpy(bytecode, gscbin.bytecode.data(), gscbin.bytecode.size());
                 scriptfile->bytecode = bytecode;
 
                 g_loaded_scripts.insert(name);
+
+                DbgPrint("[codxe][IW5][GSCLoader] loaded '%s': buffer=%p bytecode=[%p, %p)\n", name, buffer,
+                         bytecode, bytecode + gscbin.bytecodeLen);
 
                 return (XAssetHeader *)scriptfile;
             }

--- a/src/game/iw5/mp/main.cpp
+++ b/src/game/iw5/mp/main.cpp
@@ -5,13 +5,14 @@
 #include "pm.h"
 #include "script.h"
 #include "bots.h"
+#include "events.h"
 
 namespace iw5
 {
 namespace mp
 {
 
-std::set<std::string> g_loaded_scripts;
+std::map<std::string, ScriptFile *> g_loaded_scripts;
 
 const unsigned int GSC_BYTECODE_ARENA_SIZE = 256 * 1024;
 unsigned __int8 *g_gsc_bytecode_arena = nullptr;
@@ -45,6 +46,29 @@ unsigned __int8 *AllocateGSCBytecode(unsigned int size)
 bool ContainsScript(const std::string &name)
 {
     return g_loaded_scripts.find(name) != g_loaded_scripts.end();
+}
+
+void ResetLoadedScripts(bool freeScripts)
+{
+    if (!freeScripts)
+        return;
+
+    const unsigned int scriptCount = static_cast<unsigned int>(g_loaded_scripts.size());
+    const unsigned int bytecodeUsed = g_gsc_bytecode_arena_used;
+
+    for (auto it = g_loaded_scripts.begin(); it != g_loaded_scripts.end(); ++it)
+    {
+        ScriptFile *scriptfile = it->second;
+        free(const_cast<char *>(scriptfile->buffer));
+        free(scriptfile);
+    }
+
+    g_loaded_scripts.clear();
+    g_gsc_bytecode_arena = nullptr;
+    g_gsc_bytecode_arena_used = 0;
+
+    DbgPrint("[codxe][IW5][GSCLoader] VM reset: released %u scripts and invalidated %u bytecode bytes\n", scriptCount,
+             bytecodeUsed);
 }
 
 bool ShouldLoadWaypointScript(const char *name)
@@ -197,6 +221,10 @@ XAssetHeader *DB_FindXAssetHeader_Hook(XAssetType type, const char *name, int al
 {
     if (type == ASSET_TYPE_SCRIPTFILE)
     {
+        auto loadedScript = g_loaded_scripts.find(name);
+        if (loadedScript != g_loaded_scripts.end())
+            return reinterpret_cast<XAssetHeader *>(loadedScript->second);
+
         if (!ShouldLoadWaypointScript(name))
             return DB_FindXAssetHeader_Detour.GetOriginal<DB_FindXAssetHeader_t>()(type, name, allowCreateDefault);
 
@@ -236,15 +264,15 @@ XAssetHeader *DB_FindXAssetHeader_Hook(XAssetType type, const char *name, int al
                     free(buffer);
                     free(scriptfile);
                     return DB_FindXAssetHeader_Detour.GetOriginal<DB_FindXAssetHeader_t>()(type, name,
-                                                                                          allowCreateDefault);
+                                                                                           allowCreateDefault);
                 }
                 memcpy(bytecode, gscbin.bytecode.data(), gscbin.bytecode.size());
                 scriptfile->bytecode = bytecode;
 
-                g_loaded_scripts.insert(name);
+                g_loaded_scripts[name] = scriptfile;
 
-                DbgPrint("[codxe][IW5][GSCLoader] loaded '%s': buffer=%p bytecode=[%p, %p)\n", name, buffer,
-                         bytecode, bytecode + gscbin.bytecodeLen);
+                DbgPrint("[codxe][IW5][GSCLoader] loaded '%s': buffer=%p bytecode=[%p, %p)\n", name, buffer, bytecode,
+                         bytecode + gscbin.bytecodeLen);
 
                 return (XAssetHeader *)scriptfile;
             }
@@ -271,6 +299,7 @@ bool DB_IsXAssetDefault_Hook(XAssetType type, const char *name)
 IW5_MP_Plugin::IW5_MP_Plugin()
 {
     RegisterModule(new Config());
+    RegisterModule(new Events());
     RegisterModule(new Branding());
     RegisterModule(new patches());
     RegisterModule(new PlayerMovement());
@@ -282,10 +311,13 @@ IW5_MP_Plugin::IW5_MP_Plugin()
 
     DB_IsXAssetDefault_Detour = Detour(DB_IsXAssetDefault, DB_IsXAssetDefault_Hook);
     DB_IsXAssetDefault_Detour.Install();
+
+    Events::OnVMShutdown(ResetLoadedScripts);
 }
 
 IW5_MP_Plugin::~IW5_MP_Plugin()
 {
+    ResetLoadedScripts(true);
     DB_FindXAssetHeader_Detour.Remove();
     DB_IsXAssetDefault_Detour.Remove();
 }

--- a/src/game/iw5/mp/main.cpp
+++ b/src/game/iw5/mp/main.cpp
@@ -63,27 +63,6 @@ void ResetLoadedScripts(bool freeScripts)
     g_gsc_bytecode_arena_used = 0;
 }
 
-bool ShouldLoadWaypointScript(const char *name)
-{
-    std::string scriptName = name ? name : "";
-    std::replace(scriptName.begin(), scriptName.end(), '\\', '/');
-
-    const std::string waypointPrefix = "scripts/mp/mp_";
-    if (scriptName.compare(0, waypointPrefix.size(), waypointPrefix) != 0)
-        return true;
-
-    const size_t fileNameOffset = scriptName.find('/', waypointPrefix.size());
-    if (fileNameOffset == std::string::npos || scriptName.compare(fileNameOffset + 1, 4, "wps_") != 0)
-        return true;
-
-    const dvar_t *mapname = Dvar_FindMalleableVar("mapname");
-    if (!mapname || !mapname->current.string || !mapname->current.string[0])
-        return false;
-
-    const std::string currentMapPrefix = std::string("scripts/mp/") + mapname->current.string + "/";
-    return scriptName.compare(0, currentMapPrefix.size(), currentMapPrefix) == 0;
-}
-
 // Swap byte order for 32-bit integers
 uint32_t SwapEndian(uint32_t value)
 {
@@ -209,9 +188,6 @@ XAssetHeader *DB_FindXAssetHeader_Hook(XAssetType type, const char *name, int al
         auto loadedScript = g_loaded_scripts.find(name);
         if (loadedScript != g_loaded_scripts.end())
             return reinterpret_cast<XAssetHeader *>(loadedScript->second);
-
-        if (!ShouldLoadWaypointScript(name))
-            return DB_FindXAssetHeader_Detour.GetOriginal<DB_FindXAssetHeader_t>()(type, name, allowCreateDefault);
 
         std::string modBasePath = Config::GetModBasePath();
         std::string overridePath = modBasePath + "\\" + name + ".gscbin";

--- a/src/game/iw5/mp/main.cpp
+++ b/src/game/iw5/mp/main.cpp
@@ -26,8 +26,6 @@ unsigned __int8 *AllocateGSCBytecode(unsigned int size)
         g_gsc_bytecode_arena = PMem_AllocFromSource_NoDebug(GSC_BYTECODE_ARENA_SIZE, 4,
                                                             // 0 crashes on hardware, 2 crashes on Xenia.
                                                             is_xenia ? 0 : 2, PMEM_SOURCE_SCRIPT);
-        DbgPrint("[codxe][IW5][GSCLoader] bytecode arena=[%p, %p)\n", g_gsc_bytecode_arena,
-                 g_gsc_bytecode_arena + GSC_BYTECODE_ARENA_SIZE);
     }
 
     const unsigned int offset = (g_gsc_bytecode_arena_used + 3) & ~3u;
@@ -53,9 +51,6 @@ void ResetLoadedScripts(bool freeScripts)
     if (!freeScripts)
         return;
 
-    const unsigned int scriptCount = static_cast<unsigned int>(g_loaded_scripts.size());
-    const unsigned int bytecodeUsed = g_gsc_bytecode_arena_used;
-
     for (auto it = g_loaded_scripts.begin(); it != g_loaded_scripts.end(); ++it)
     {
         ScriptFile *scriptfile = it->second;
@@ -66,9 +61,6 @@ void ResetLoadedScripts(bool freeScripts)
     g_loaded_scripts.clear();
     g_gsc_bytecode_arena = nullptr;
     g_gsc_bytecode_arena_used = 0;
-
-    DbgPrint("[codxe][IW5][GSCLoader] VM reset: released %u scripts and invalidated %u bytecode bytes\n", scriptCount,
-             bytecodeUsed);
 }
 
 bool ShouldLoadWaypointScript(const char *name)
@@ -86,17 +78,10 @@ bool ShouldLoadWaypointScript(const char *name)
 
     const dvar_t *mapname = Dvar_FindMalleableVar("mapname");
     if (!mapname || !mapname->current.string || !mapname->current.string[0])
-    {
-        DbgPrint("[codxe][IW5][GSCLoader] skipping waypoint '%s': mapname is unavailable\n", name);
         return false;
-    }
 
     const std::string currentMapPrefix = std::string("scripts/mp/") + mapname->current.string + "/";
-    const bool shouldLoad = scriptName.compare(0, currentMapPrefix.size(), currentMapPrefix) == 0;
-    if (!shouldLoad)
-        DbgPrint("[codxe][IW5][GSCLoader] skipping waypoint '%s' for map '%s'\n", name, mapname->current.string);
-
-    return shouldLoad;
+    return scriptName.compare(0, currentMapPrefix.size(), currentMapPrefix) == 0;
 }
 
 // Swap byte order for 32-bit integers
@@ -241,9 +226,6 @@ XAssetHeader *DB_FindXAssetHeader_Hook(XAssetType type, const char *name, int al
             }
             else
             {
-                DbgPrint("[codxe][IW5][GSCLoader] loading '%s': compressed=%u bytecode=%u total=%u\n", name,
-                         gscbin.compressedLen, gscbin.bytecodeLen, gscbin.compressedLen + gscbin.bytecodeLen);
-
                 // ProcessScript treats these as persistent writable data. Keeping them on the heap avoids
                 // consuming a 64 KiB script page for each small allocation.
                 ScriptFile *scriptfile = static_cast<ScriptFile *>(malloc(sizeof(ScriptFile)));
@@ -270,9 +252,6 @@ XAssetHeader *DB_FindXAssetHeader_Hook(XAssetType type, const char *name, int al
                 scriptfile->bytecode = bytecode;
 
                 g_loaded_scripts[name] = scriptfile;
-
-                DbgPrint("[codxe][IW5][GSCLoader] loaded '%s': buffer=%p bytecode=[%p, %p)\n", name, buffer, bytecode,
-                         bytecode + gscbin.bytecodeLen);
 
                 return (XAssetHeader *)scriptfile;
             }

--- a/src/game/iw5/mp/patches.cpp
+++ b/src/game/iw5/mp/patches.cpp
@@ -46,6 +46,14 @@ void DisableDvarWriteChecks()
 }
 
 Detour Jump_Start_Detour;
+Detour CL_ConsolePrint_Detour;
+
+void CL_ConsolePrint_Hook(LocalClientNum_t localClientNum, int channel, const char *txt, unsigned int duration,
+                          unsigned int pixelWidth, int flags)
+{
+    DbgPrint("[codxe][IW5][CL_ConsolePrint] %s", txt ? txt : "<null>");
+    CL_ConsolePrint_Detour.GetOriginal<CL_ConsolePrint_t>()(localClientNum, channel, txt, duration, pixelWidth, flags);
+}
 
 void Jump_Start_Hook(pmove_t *pm, pml_t *pml, double height)
 {
@@ -61,10 +69,14 @@ patches::patches()
 
     Jump_Start_Detour = Detour(Jump_Start, Jump_Start_Hook);
     Jump_Start_Detour.Install();
+
+    CL_ConsolePrint_Detour = Detour(CL_ConsolePrint, CL_ConsolePrint_Hook);
+    CL_ConsolePrint_Detour.Install();
 }
 
 patches::~patches()
 {
+    CL_ConsolePrint_Detour.Remove();
     Jump_Start_Detour.Remove();
 }
 } // namespace mp

--- a/src/game/iw5/mp/script.cpp
+++ b/src/game/iw5/mp/script.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "script.h"
+#include "bots.h"
 
 namespace iw5
 {
@@ -152,6 +153,8 @@ Script::Script()
     Scr_AddMethod("getentityflags", PlayerCmd_GetEntityFlags);
 
     Scr_AddMethod("disablebrushcollisionatorigin", DisableBrushCollisionAtOrigin);
+
+    Scr_AddMethod("spawnbot", SpawnBot);
 
     PlayerCmd_GetViewmodel_Detour = Detour(PlayerCmd_GetViewmodel, PlayerCmd_GetViewmodel_Hook);
     PlayerCmd_GetViewmodel_Detour.Install();

--- a/src/game/iw5/mp/script.cpp
+++ b/src/game/iw5/mp/script.cpp
@@ -7,17 +7,7 @@ namespace iw5
 namespace mp
 {
 
-std::map<std::string, BuiltinFunction> scr_functions;
 std::map<std::string, BuiltinMethod> scr_methods;
-
-void Scr_AddFunction(const std::string &name, BuiltinFunction func)
-{
-    auto result = scr_functions.insert(std::make_pair(name, func));
-    if (!result.second)
-    {
-        throw std::runtime_error("Function '" + name + "' already exists");
-    }
-}
 
 void Scr_AddMethod(const std::string &name, const BuiltinMethod func)
 {
@@ -128,17 +118,36 @@ void RemoveBrushCollisions()
 }
 
 Detour PlayerCmd_GetViewmodel_Detour;
+Detour Scr_GetFunction_Detour;
+
+unsigned int Scr_GetFunction_Hook(const char **pName, int *type)
+{
+    const char *requestedName = pName && *pName ? *pName : nullptr;
+    const unsigned int result = Scr_GetFunction_Detour.GetOriginal<decltype(Scr_GetFunction)>()(pName, type);
+
+    if (requestedName && !result)
+        DbgPrint("[codxe][IW5][GSC] unresolved builtin function '%s'\n", requestedName);
+
+    if (!pName)
+    {
+        ResetBotState();
+        // Retail registers addtestclient (0xEE), but its implementation is empty.
+        Scr_RegisterFunction(reinterpret_cast<int>(GScr_AddTestClient), 0, 0xEE);
+        DbgPrint("[codxe][IW5][Bots] registered addtestclient token 0xEE at %p\n", GScr_AddTestClient);
+    }
+
+    return result;
+}
 
 void PlayerCmd_GetViewmodel_Hook(scr_entref_t entref)
 {
-    const char *s1 = Scr_GetString(0);
-    const std::string arg1 = (s1 ? std::string(s1) : std::string());
-    DbgPrint("arg1=%s\n", arg1.c_str());
-    auto it = scr_methods.find(arg1);
-    if (it != scr_methods.end())
+    if (Scr_GetNumParam() > 0)
     {
-        DbgPrint("Found function '%s', calling it\n", arg1.c_str());
-        return it->second(entref);
+        const char *selector = Scr_GetString(0);
+        const std::string name = selector ? selector : "";
+        auto it = scr_methods.find(name);
+        if (it != scr_methods.end())
+            return it->second(entref);
     }
 
     PlayerCmd_GetViewmodel_Detour.GetOriginal<PlayerCmd_GetViewmodel_t>()(entref);
@@ -154,7 +163,14 @@ Script::Script()
 
     Scr_AddMethod("disablebrushcollisionatorigin", DisableBrushCollisionAtOrigin);
 
-    Scr_AddMethod("spawnbot", SpawnBot);
+    Scr_AddMethod("botaction", PlayerCmd_BotAction);
+    Scr_AddMethod("botstop", PlayerCmd_BotStop);
+    Scr_AddMethod("botmovement", PlayerCmd_BotMovement);
+    Scr_AddMethod("botmeleeparams", PlayerCmd_BotMeleeParams);
+    Scr_AddMethod("botremoteangles", PlayerCmd_BotRemoteAngles);
+    Scr_AddMethod("botangles", PlayerCmd_BotAngles);
+    Scr_GetFunction_Detour = Detour(Scr_GetFunction, Scr_GetFunction_Hook);
+    Scr_GetFunction_Detour.Install();
 
     PlayerCmd_GetViewmodel_Detour = Detour(PlayerCmd_GetViewmodel, PlayerCmd_GetViewmodel_Hook);
     PlayerCmd_GetViewmodel_Detour.Install();
@@ -163,6 +179,7 @@ Script::Script()
 Script::~Script()
 {
     PlayerCmd_GetViewmodel_Detour.Remove();
+    Scr_GetFunction_Detour.Remove();
 }
 } // namespace mp
 } // namespace iw5

--- a/src/game/iw5/mp/script.cpp
+++ b/src/game/iw5/mp/script.cpp
@@ -306,11 +306,7 @@ Detour Scr_GetFunction_Detour;
 
 unsigned int Scr_GetFunction_Hook(const char **pName, int *type)
 {
-    const char *requestedName = pName && *pName ? *pName : nullptr;
     const unsigned int result = Scr_GetFunction_Detour.GetOriginal<decltype(Scr_GetFunction)>()(pName, type);
-
-    if (requestedName && !result)
-        DbgPrint("[codxe][IW5][GSC] unresolved builtin function '%s'\n", requestedName);
 
     if (!pName)
     {
@@ -322,8 +318,6 @@ unsigned int Scr_GetFunction_Hook(const char **pName, int *type)
         Scr_RegisterFunction(reinterpret_cast<int>(GScr_CloseFile), 0, GSC_TOKEN_CLOSEFILE);
         Scr_RegisterFunction(reinterpret_cast<int>(GScr_WriteLine), 0, GSC_TOKEN_FPRINTLN);
         Scr_RegisterFunction(reinterpret_cast<int>(GScr_ReadLine), 0, GSC_TOKEN_FREADLN);
-        DbgPrint("[codxe][IW5][Bots] registered addtestclient token 0xEE at %p\n", GScr_AddTestClient);
-        DbgPrint("[codxe][IW5][GSC] registered streaming file functions\n");
     }
 
     return result;

--- a/src/game/iw5/mp/script.cpp
+++ b/src/game/iw5/mp/script.cpp
@@ -7,6 +7,190 @@ namespace iw5
 namespace mp
 {
 
+namespace
+{
+static const int MAX_SCRIPT_FILE_HANDLES = 8;
+static const unsigned int GSC_TOKEN_OPENFILE = 0x99;
+static const unsigned int GSC_TOKEN_CLOSEFILE = 0x9A;
+static const unsigned int GSC_TOKEN_FPRINTLN = 0x9B;
+static const unsigned int GSC_TOKEN_FREADLN = 0x9D;
+
+struct ScriptFileHandle
+{
+    FILE *file;
+};
+
+ScriptFileHandle script_file_handles[MAX_SCRIPT_FILE_HANDLES];
+
+std::string BuildScriptFilePath(const char *filename)
+{
+    std::string relative_path = filename ? filename : "";
+    std::replace(relative_path.begin(), relative_path.end(), '/', '\\');
+
+    const std::string mod_base_path = Config::GetModBasePath();
+    if (mod_base_path.empty())
+        return relative_path;
+
+    return mod_base_path + "\\" + relative_path;
+}
+
+void EnsureParentDirectory(const std::string &path)
+{
+    char directory[MAX_PATH];
+    strncpy(directory, path.c_str(), sizeof(directory) - 1);
+    directory[sizeof(directory) - 1] = '\0';
+
+    char *last_slash = strrchr(directory, '\\');
+    if (last_slash)
+    {
+        *last_slash = '\0';
+        filesystem::create_nested_dirs(directory);
+    }
+}
+
+void CloseAllScriptFiles()
+{
+    for (int i = 0; i < MAX_SCRIPT_FILE_HANDLES; ++i)
+    {
+        if (script_file_handles[i].file)
+        {
+            fclose(script_file_handles[i].file);
+            script_file_handles[i].file = nullptr;
+        }
+    }
+}
+
+void GScr_OpenFile()
+{
+    if (Scr_GetNumParam() != 2)
+    {
+        DbgPrint("[codxe][IW5][GSC] openfile expects 2 parameters\n");
+        Scr_ErrorInternal();
+        return;
+    }
+
+    const char *mode = Scr_GetString(1);
+    const char *file_mode = nullptr;
+    if (!_stricmp(mode, "read"))
+        file_mode = "rt";
+    else if (!_stricmp(mode, "write"))
+        file_mode = "wt";
+    else if (!_stricmp(mode, "append"))
+        file_mode = "at";
+    else
+    {
+        DbgPrint("[codxe][IW5][GSC] openfile received invalid mode '%s'\n", mode);
+        Scr_AddInt(0);
+        return;
+    }
+
+    const char *filename = Scr_GetString(0);
+    const std::string path = BuildScriptFilePath(filename);
+    if (file_mode[0] == 'w' || file_mode[0] == 'a')
+        EnsureParentDirectory(path);
+
+    for (int i = 0; i < MAX_SCRIPT_FILE_HANDLES; ++i)
+    {
+        if (!script_file_handles[i].file)
+        {
+            script_file_handles[i].file = fopen(path.c_str(), file_mode);
+            if (!script_file_handles[i].file)
+            {
+                Scr_AddInt(0);
+                return;
+            }
+
+            Scr_AddInt(i + 1);
+            return;
+        }
+    }
+
+    DbgPrint("[codxe][IW5][GSC] openfile exhausted its file handles\n");
+    Scr_AddInt(0);
+}
+
+void GScr_CloseFile()
+{
+    if (Scr_GetNumParam() != 1)
+    {
+        DbgPrint("[codxe][IW5][GSC] closefile expects 1 parameter\n");
+        Scr_ErrorInternal();
+        return;
+    }
+
+    const int handle = Scr_GetInt(0);
+    if (handle < 1 || handle > MAX_SCRIPT_FILE_HANDLES)
+    {
+        DbgPrint("[codxe][IW5][GSC] closefile received invalid handle %d\n", handle);
+        Scr_AddInt(0);
+        return;
+    }
+
+    ScriptFileHandle &slot = script_file_handles[handle - 1];
+    if (!slot.file)
+    {
+        Scr_AddInt(0);
+        return;
+    }
+
+    const int result = fclose(slot.file);
+    slot.file = nullptr;
+    Scr_AddInt(result == 0);
+}
+
+void GScr_ReadLine()
+{
+    if (Scr_GetNumParam() != 1)
+    {
+        DbgPrint("[codxe][IW5][GSC] freadln expects 1 parameter\n");
+        Scr_ErrorInternal();
+        return;
+    }
+
+    const int handle = Scr_GetInt(0);
+    if (handle < 1 || handle > MAX_SCRIPT_FILE_HANDLES || !script_file_handles[handle - 1].file)
+    {
+        DbgPrint("[codxe][IW5][GSC] freadln received invalid handle %d\n", handle);
+        Scr_AddUndefined();
+        return;
+    }
+
+    char line[4096];
+    if (!fgets(line, sizeof(line), script_file_handles[handle - 1].file))
+    {
+        Scr_AddUndefined();
+        return;
+    }
+
+    size_t length = strlen(line);
+    while (length && (line[length - 1] == '\n' || line[length - 1] == '\r'))
+        line[--length] = '\0';
+
+    Scr_AddString(line);
+}
+
+void GScr_WriteLine()
+{
+    if (Scr_GetNumParam() != 2)
+    {
+        DbgPrint("[codxe][IW5][GSC] fprintln expects 2 parameters\n");
+        Scr_ErrorInternal();
+        return;
+    }
+
+    const int handle = Scr_GetInt(0);
+    if (handle < 1 || handle > MAX_SCRIPT_FILE_HANDLES || !script_file_handles[handle - 1].file)
+    {
+        DbgPrint("[codxe][IW5][GSC] fprintln received invalid handle %d\n", handle);
+        Scr_AddInt(0);
+        return;
+    }
+
+    const char *contents = Scr_GetString(1);
+    Scr_AddInt(fprintf(script_file_handles[handle - 1].file, "%s\n", contents) >= 0);
+}
+} // namespace
+
 std::map<std::string, BuiltinMethod> scr_methods;
 
 void Scr_AddMethod(const std::string &name, const BuiltinMethod func)
@@ -130,10 +314,16 @@ unsigned int Scr_GetFunction_Hook(const char **pName, int *type)
 
     if (!pName)
     {
+        CloseAllScriptFiles();
         ResetBotState();
         // Retail registers addtestclient (0xEE), but its implementation is empty.
         Scr_RegisterFunction(reinterpret_cast<int>(GScr_AddTestClient), 0, 0xEE);
+        Scr_RegisterFunction(reinterpret_cast<int>(GScr_OpenFile), 0, GSC_TOKEN_OPENFILE);
+        Scr_RegisterFunction(reinterpret_cast<int>(GScr_CloseFile), 0, GSC_TOKEN_CLOSEFILE);
+        Scr_RegisterFunction(reinterpret_cast<int>(GScr_WriteLine), 0, GSC_TOKEN_FPRINTLN);
+        Scr_RegisterFunction(reinterpret_cast<int>(GScr_ReadLine), 0, GSC_TOKEN_FREADLN);
         DbgPrint("[codxe][IW5][Bots] registered addtestclient token 0xEE at %p\n", GScr_AddTestClient);
+        DbgPrint("[codxe][IW5][GSC] registered streaming file functions\n");
     }
 
     return result;
@@ -178,6 +368,7 @@ Script::Script()
 
 Script::~Script()
 {
+    CloseAllScriptFiles();
     PlayerCmd_GetViewmodel_Detour.Remove();
     Scr_GetFunction_Detour.Remove();
 }

--- a/src/game/iw5/mp/structs.h
+++ b/src/game/iw5/mp/structs.h
@@ -1087,12 +1087,20 @@ struct client_t
     gentity_s *gentity;
     char pad1[67772];
     int bIsSplitscreenClient;
-    char pad2[224928];
+    char pad2[13830];
+    uint16_t scriptId;
+    char pad3[4];
+    int bIsTestClient;
+    char pad4[211088];
 };
 static_assert(sizeof(client_t) == 428928, "");
+static_assert(offsetof(client_t, header) == 0, "");
 static_assert(offsetof(client_t, userinfo) == 1636, "");
 static_assert(offsetof(client_t, gentity) == 136220, "");
 static_assert(offsetof(client_t, bIsSplitscreenClient) == 203996, "");
+static_assert(offsetof(client_t, scriptId) == 217830, "");
+static_assert(offsetof(client_t, bIsTestClient) == 217836, "");
+
 
 enum trType_t : __int32
 {
@@ -1898,6 +1906,15 @@ struct ScreenPlacement
     float subScreenLeft;
 };
 
+// Custom Structs
+
+struct SpawnBotOptions
+{
+    int entNum;
+    int level;
+    int prestige;
+};
+
 // Function typedefs
 
 typedef void (*CG_GameMessage_t)(LocalClientNum_t localClientNum, const char *msg);
@@ -1923,6 +1940,8 @@ typedef gentity_s *(*GetEntity_t)(scr_entref_t entref);
 typedef int (*Scr_GetInt_t)(unsigned int index);
 typedef unsigned int (*Scr_GetMethod_t)(const char **pName, int *type);
 typedef const char *(*Scr_GetString_t)(unsigned int index);
+typedef int (*Sl_GetString_t)(const char* string, int user);
+typedef unsigned int (*Scr_GetNumParam_t)();
 
 typedef const ScreenPlacement *(*ScrPlace_GetActivePlacement_t)(const LocalClientNum_t localClientNum);
 
@@ -1937,6 +1956,8 @@ typedef void (*UI_DrawText_t)(const ScreenPlacement *scrPlace, const char *text,
 typedef gentity_s *(*Weapon_RocketLauncher_Fire_t)(gentity_s *ent, const Weapon *weapon, double spread, weaponParms *wp,
                                                    weaponParms *gunVel, missileFireParms *fireParms,
                                                    missileFireParms *magicBullet, bool a8);
+
+typedef void (*SV_DropClient_t)(client_t *cl, const char *reason, bool tellThem);
 
 } // namespace mp
 } // namespace iw5

--- a/src/game/iw5/mp/structs.h
+++ b/src/game/iw5/mp/structs.h
@@ -1101,7 +1101,6 @@ static_assert(offsetof(client_t, bIsSplitscreenClient) == 203996, "");
 static_assert(offsetof(client_t, scriptId) == 217830, "");
 static_assert(offsetof(client_t, bIsTestClient) == 217836, "");
 
-
 enum trType_t : __int32
 {
     TR_STATIONARY = 0x0,
@@ -1940,7 +1939,7 @@ typedef gentity_s *(*GetEntity_t)(scr_entref_t entref);
 typedef int (*Scr_GetInt_t)(unsigned int index);
 typedef unsigned int (*Scr_GetMethod_t)(const char **pName, int *type);
 typedef const char *(*Scr_GetString_t)(unsigned int index);
-typedef int (*Sl_GetString_t)(const char* string, int user);
+typedef int (*Sl_GetString_t)(const char *string, int user);
 typedef unsigned int (*Scr_GetNumParam_t)();
 
 typedef const ScreenPlacement *(*ScrPlace_GetActivePlacement_t)(const LocalClientNum_t localClientNum);

--- a/src/game/iw5/mp/structs.h
+++ b/src/game/iw5/mp/structs.h
@@ -767,6 +767,8 @@ struct __declspec(align(32)) playerState_s
     int diveDirection;
     int stunTime;
 };
+static_assert(offsetof(playerState_s, weapCommon.offHand) == 868, "");
+static_assert(offsetof(playerState_s, weapCommon.weapon) == 880, "");
 
 enum sessionState_t : __int32
 {
@@ -801,6 +803,15 @@ struct __declspec(align(2)) usercmd_s
     char remoteControlMove[3];
 };
 static_assert(sizeof(usercmd_s) == 44, "");
+static_assert(offsetof(usercmd_s, serverTime) == 0, "");
+static_assert(offsetof(usercmd_s, buttons) == 4, "");
+static_assert(offsetof(usercmd_s, angles) == 8, "");
+static_assert(offsetof(usercmd_s, weapon) == 20, "");
+static_assert(offsetof(usercmd_s, offHand) == 24, "");
+static_assert(offsetof(usercmd_s, forwardmove) == 28, "");
+static_assert(offsetof(usercmd_s, meleeChargeEnt) == 32, "");
+static_assert(offsetof(usercmd_s, meleeChargeDist) == 34, "");
+static_assert(offsetof(usercmd_s, remoteControlAngles) == 38, "");
 
 struct playerTeamState_t
 {
@@ -1016,6 +1027,7 @@ struct netadr_t
     unsigned __int16 port;
     netsrc_t localNetID;
 };
+static_assert(sizeof(netadr_t) == 16, "");
 
 struct netProfilePacket_t
 {
@@ -1083,9 +1095,15 @@ struct client_t
     clientHeader_t header;
     const char *dropReason;
     char *userinfo;
-    char pad01[134580];
+    char pad01a[133116];
+    int reliableSequence;
+    int reliableAcknowledge;
+    int reliableSent;
+    char pad01b[1452];
     gentity_s *gentity;
-    char pad1[67772];
+    char pad1a[116];
+    int lastPacketTime;
+    char pad1b[67652];
     int bIsSplitscreenClient;
     char pad2[13830];
     uint16_t scriptId;
@@ -1096,7 +1114,11 @@ struct client_t
 static_assert(sizeof(client_t) == 428928, "");
 static_assert(offsetof(client_t, header) == 0, "");
 static_assert(offsetof(client_t, userinfo) == 1636, "");
+static_assert(offsetof(client_t, reliableSequence) == 134756, "");
+static_assert(offsetof(client_t, reliableAcknowledge) == 134760, "");
+static_assert(offsetof(client_t, reliableSent) == 134764, "");
 static_assert(offsetof(client_t, gentity) == 136220, "");
+static_assert(offsetof(client_t, lastPacketTime) == 136340, "");
 static_assert(offsetof(client_t, bIsSplitscreenClient) == 203996, "");
 static_assert(offsetof(client_t, scriptId) == 217830, "");
 static_assert(offsetof(client_t, bIsTestClient) == 217836, "");
@@ -1905,19 +1927,12 @@ struct ScreenPlacement
     float subScreenLeft;
 };
 
-// Custom Structs
-
-struct SpawnBotOptions
-{
-    int entNum;
-    int level;
-    int prestige;
-};
-
 // Function typedefs
 
 typedef void (*CG_GameMessage_t)(LocalClientNum_t localClientNum, const char *msg);
 
+typedef void (*CL_ConsolePrint_t)(LocalClientNum_t localClientNum, int channel, const char *txt,
+                                  unsigned int duration, unsigned int pixelWidth, int flags);
 typedef Font_s *(*CL_RegisterFont_t)(const char *fontName, int imageTrack);
 
 typedef XAssetEntry *(*DB_FindXAssetEntry_t)(XAssetType type, const char *name);

--- a/src/game/iw5/mp/structs.h
+++ b/src/game/iw5/mp/structs.h
@@ -1934,8 +1934,6 @@ struct ScreenPlacement
 
 typedef void (*CG_GameMessage_t)(LocalClientNum_t localClientNum, const char *msg);
 
-typedef void (*CL_ConsolePrint_t)(LocalClientNum_t localClientNum, int channel, const char *txt, unsigned int duration,
-                                  unsigned int pixelWidth, int flags);
 typedef Font_s *(*CL_RegisterFont_t)(const char *fontName, int imageTrack);
 
 typedef XAssetEntry *(*DB_FindXAssetEntry_t)(XAssetType type, const char *name);

--- a/src/game/iw5/mp/structs.h
+++ b/src/game/iw5/mp/structs.h
@@ -1973,5 +1973,7 @@ typedef gentity_s *(*Weapon_RocketLauncher_Fire_t)(gentity_s *ent, const Weapon 
 
 typedef void (*SV_DropClient_t)(client_t *cl, const char *reason, bool tellThem);
 
+typedef int *(*G_SelectWeapon_t)(int clientNum, Weapon weapon);
+
 } // namespace mp
 } // namespace iw5

--- a/src/game/iw5/mp/structs.h
+++ b/src/game/iw5/mp/structs.h
@@ -1934,6 +1934,8 @@ struct ScreenPlacement
 
 typedef void (*CG_GameMessage_t)(LocalClientNum_t localClientNum, const char *msg);
 
+typedef void (*CL_ConsolePrint_t)(LocalClientNum_t localClientNum, int channel, const char *txt, unsigned int duration,
+                                  unsigned int pixelWidth, int flags);
 typedef Font_s *(*CL_RegisterFont_t)(const char *fontName, int imageTrack);
 
 typedef XAssetEntry *(*DB_FindXAssetEntry_t)(XAssetType type, const char *name);

--- a/src/game/iw5/mp/structs.h
+++ b/src/game/iw5/mp/structs.h
@@ -1931,8 +1931,8 @@ struct ScreenPlacement
 
 typedef void (*CG_GameMessage_t)(LocalClientNum_t localClientNum, const char *msg);
 
-typedef void (*CL_ConsolePrint_t)(LocalClientNum_t localClientNum, int channel, const char *txt,
-                                  unsigned int duration, unsigned int pixelWidth, int flags);
+typedef void (*CL_ConsolePrint_t)(LocalClientNum_t localClientNum, int channel, const char *txt, unsigned int duration,
+                                  unsigned int pixelWidth, int flags);
 typedef Font_s *(*CL_RegisterFont_t)(const char *fontName, int imageTrack);
 
 typedef XAssetEntry *(*DB_FindXAssetEntry_t)(XAssetType type, const char *name);
@@ -1948,7 +1948,10 @@ typedef void (*Jump_Start_t)(pmove_t *pm, pml_t *pml, double height);
 typedef unsigned __int8 *(*PMem_AllocFromSource_NoDebug_t)(unsigned int size, unsigned int alignment, unsigned int type,
                                                            PMem_Source source);
 
+typedef void (*G_ShutdownGame_t)(int freeScripts);
+
 typedef void (*Scr_AddInt_t)(int value);
+typedef void (*Scr_AddUndefined_t)();
 typedef void (*Scr_ErrorInternal_t)();
 typedef gentity_s *(*GetEntity_t)(scr_entref_t entref);
 typedef int (*Scr_GetInt_t)(unsigned int index);

--- a/src/game/iw5/mp/structs.h
+++ b/src/game/iw5/mp/structs.h
@@ -1103,7 +1103,9 @@ struct client_t
     gentity_s *gentity;
     char pad1a[116];
     int lastPacketTime;
-    char pad1b[67652];
+    char pad1b[16];
+    int ping;
+    char pad1c[67632];
     int bIsSplitscreenClient;
     char pad2[13830];
     uint16_t scriptId;
@@ -1119,6 +1121,7 @@ static_assert(offsetof(client_t, reliableAcknowledge) == 134760, "");
 static_assert(offsetof(client_t, reliableSent) == 134764, "");
 static_assert(offsetof(client_t, gentity) == 136220, "");
 static_assert(offsetof(client_t, lastPacketTime) == 136340, "");
+static_assert(offsetof(client_t, ping) == 136360, "");
 static_assert(offsetof(client_t, bIsSplitscreenClient) == 203996, "");
 static_assert(offsetof(client_t, scriptId) == 217830, "");
 static_assert(offsetof(client_t, bIsTestClient) == 217836, "");

--- a/src/game/iw5/mp/symbols.h
+++ b/src/game/iw5/mp/symbols.h
@@ -76,6 +76,5 @@ static auto SV_ClientEnterWorld = reinterpret_cast<void (*)(client_t *cl, usercm
 
 static auto SV_DropClient = reinterpret_cast<SV_DropClient_t>(0x822C66A8);
 
-
 } // namespace mp
 } // namespace iw5

--- a/src/game/iw5/mp/symbols.h
+++ b/src/game/iw5/mp/symbols.h
@@ -19,7 +19,8 @@ static auto level = reinterpret_cast<level_locals_t *>(0x82FDA080);
 
 static auto sharedUiInfo = reinterpret_cast<sharedUiInfo_t *>(0x836EE5B0);
 
-static auto svs_clients = reinterpret_cast<client_t *>(0x836C6310);
+static auto svs_numclients = reinterpret_cast<int *>(0x836C630C);
+static auto svs_clients = reinterpret_cast<client_t **>(0x836C6310);
 
 // Function pointers
 
@@ -45,6 +46,12 @@ static auto Scr_ErrorInternal = reinterpret_cast<Scr_ErrorInternal_t>(0x822BD368
 static auto Scr_GetInt = reinterpret_cast<Scr_GetInt_t>(0x822BEB30);
 static auto Scr_GetMethod = reinterpret_cast<Scr_GetMethod_t>(0x822661A0);
 static auto Scr_GetString = reinterpret_cast<Scr_GetString_t>(0x822BF108);
+static auto SL_GetString = reinterpret_cast<Sl_GetString_t>(0x822B5CC8);
+static auto Scr_GetNumParam = reinterpret_cast<Scr_GetNumParam_t>(0x822BFA70);
+static auto Scr_AddString = reinterpret_cast<void (*)(char *value)>(0x822BFC68);
+static auto Scr_NotifyNum =
+    reinterpret_cast<void (*)(int entnum, unsigned int classnum, unsigned int stringValue, unsigned int paramcount)>(
+        0x822BE548);
 
 static auto ScrPlace_GetActivePlacement = reinterpret_cast<ScrPlace_GetActivePlacement_t>(0x821A69E8);
 
@@ -57,6 +64,18 @@ static auto UI_DrawBuildNumber = reinterpret_cast<UI_DrawBuildNumber_t>(0x822ECA
 static auto UI_DrawText = reinterpret_cast<UI_DrawText_t>(0x822EC490);
 
 static auto Weapon_RocketLauncher_Fire = reinterpret_cast<Weapon_RocketLauncher_Fire_t>(0x82271710);
+
+static auto G_IRand = reinterpret_cast<int (*)(int min, int max)>(0x8226FC80);
+static auto GetProtocolVersion = reinterpret_cast<int (*)()>(0x8232A320);
+static auto BG_NetDataChecksum = reinterpret_cast<int (*)()>(0x820E0B50);
+static auto SV_Cmd_TokenizeString = reinterpret_cast<void (*)(const char *text)>(0x822889F0);
+static auto SV_DirectConnect = reinterpret_cast<void (*)(netadr_t from, int client)>(0x822C8AB0);
+static auto SV_Cmd_EndTokenizedString = reinterpret_cast<void (*)()>(0x82288A10);
+static auto SV_SendClientGameState = reinterpret_cast<void (*)(client_t *cl)>(0x822C6DD0);
+static auto SV_ClientEnterWorld = reinterpret_cast<void (*)(client_t *cl, usercmd_s *cmd)>(0x822C6F50);
+
+static auto SV_DropClient = reinterpret_cast<SV_DropClient_t>(0x822C66A8);
+
 
 } // namespace mp
 } // namespace iw5

--- a/src/game/iw5/mp/symbols.h
+++ b/src/game/iw5/mp/symbols.h
@@ -37,11 +37,14 @@ static auto DB_IsXAssetDefault = reinterpret_cast<DB_IsXAssetDefault_t>(0x821EEE
 
 static auto Dvar_FindMalleableVar = reinterpret_cast<Dvar_FindMalleableVar_t>(0x8232E100);
 
+static auto G_ShutdownGame = reinterpret_cast<G_ShutdownGame_t>(0x82244378);
+
 static auto Jump_Start = reinterpret_cast<Jump_Start_t>(0x820DAF00);
 
 static auto PMem_AllocFromSource_NoDebug = reinterpret_cast<PMem_AllocFromSource_NoDebug_t>(0x823335F0);
 
 static auto Scr_AddInt = reinterpret_cast<Scr_AddInt_t>(0x822BFAB8);
+static auto Scr_AddUndefined = reinterpret_cast<Scr_AddUndefined_t>(0x822BFB60);
 static auto GetEntity = reinterpret_cast<GetEntity_t>(0x82251470);
 static auto Scr_ErrorInternal = reinterpret_cast<Scr_ErrorInternal_t>(0x822BD368);
 static auto Scr_GetInt = reinterpret_cast<Scr_GetInt_t>(0x822BEB30);

--- a/src/game/iw5/mp/symbols.h
+++ b/src/game/iw5/mp/symbols.h
@@ -26,6 +26,7 @@ static auto svs_clients = reinterpret_cast<client_t **>(0x836C6310);
 
 static auto CG_GameMessage = reinterpret_cast<CG_GameMessage_t>(0x82127BF8);
 
+static auto CL_ConsolePrint = reinterpret_cast<CL_ConsolePrint_t>(0x82168BB8);
 static auto CL_RegisterFont = reinterpret_cast<CL_RegisterFont_t>(0x82174F88);
 
 static auto DB_FindXAssetEntry = reinterpret_cast<DB_FindXAssetEntry_t>(0x821EE920);
@@ -44,6 +45,10 @@ static auto Scr_AddInt = reinterpret_cast<Scr_AddInt_t>(0x822BFAB8);
 static auto GetEntity = reinterpret_cast<GetEntity_t>(0x82251470);
 static auto Scr_ErrorInternal = reinterpret_cast<Scr_ErrorInternal_t>(0x822BD368);
 static auto Scr_GetInt = reinterpret_cast<Scr_GetInt_t>(0x822BEB30);
+static auto Scr_GetFloat = reinterpret_cast<float (*)(unsigned int index)>(0x822BEDD8);
+static auto Scr_AddEntityNum = reinterpret_cast<void (*)(int entnum, unsigned int classnum)>(0x822BFBD0);
+static auto Scr_RegisterFunction = reinterpret_cast<void (*)(int func, int type, unsigned int name)>(0x822B13E8);
+static auto Scr_GetFunction = reinterpret_cast<unsigned int (*)(const char **pName, int *type)>(0x822660E8);
 static auto Scr_GetMethod = reinterpret_cast<Scr_GetMethod_t>(0x822661A0);
 static auto Scr_GetString = reinterpret_cast<Scr_GetString_t>(0x822BF108);
 static auto SL_GetString = reinterpret_cast<Sl_GetString_t>(0x822B5CC8);
@@ -69,10 +74,11 @@ static auto G_IRand = reinterpret_cast<int (*)(int min, int max)>(0x8226FC80);
 static auto GetProtocolVersion = reinterpret_cast<int (*)()>(0x8232A320);
 static auto BG_NetDataChecksum = reinterpret_cast<int (*)()>(0x820E0B50);
 static auto SV_Cmd_TokenizeString = reinterpret_cast<void (*)(const char *text)>(0x822889F0);
-static auto SV_DirectConnect = reinterpret_cast<void (*)(netadr_t from, int client)>(0x822C8AB0);
+static auto SV_DirectConnect = reinterpret_cast<void (*)(netadr_t from)>(0x822C8AB0);
 static auto SV_Cmd_EndTokenizedString = reinterpret_cast<void (*)()>(0x82288A10);
 static auto SV_SendClientGameState = reinterpret_cast<void (*)(client_t *cl)>(0x822C6DD0);
 static auto SV_ClientEnterWorld = reinterpret_cast<void (*)(client_t *cl, usercmd_s *cmd)>(0x822C6F50);
+static auto SV_ClientThink = reinterpret_cast<void (*)(client_t *cl, usercmd_s *cmd)>(0x822C7D60);
 
 static auto SV_DropClient = reinterpret_cast<SV_DropClient_t>(0x822C66A8);
 

--- a/src/game/iw5/mp/symbols.h
+++ b/src/game/iw5/mp/symbols.h
@@ -79,6 +79,7 @@ static auto SV_Cmd_EndTokenizedString = reinterpret_cast<void (*)()>(0x82288A10)
 static auto SV_SendClientGameState = reinterpret_cast<void (*)(client_t *cl)>(0x822C6DD0);
 static auto SV_ClientEnterWorld = reinterpret_cast<void (*)(client_t *cl, usercmd_s *cmd)>(0x822C6F50);
 static auto SV_ClientThink = reinterpret_cast<void (*)(client_t *cl, usercmd_s *cmd)>(0x822C7D60);
+static auto G_SelectWeapon = reinterpret_cast<G_SelectWeapon_t>(0x82272800);
 
 static auto SV_DropClient = reinterpret_cast<SV_DropClient_t>(0x822C66A8);
 

--- a/src/game/iw5/mp/symbols.h
+++ b/src/game/iw5/mp/symbols.h
@@ -82,6 +82,7 @@ static auto SV_Cmd_EndTokenizedString = reinterpret_cast<void (*)()>(0x82288A10)
 static auto SV_SendClientGameState = reinterpret_cast<void (*)(client_t *cl)>(0x822C6DD0);
 static auto SV_ClientEnterWorld = reinterpret_cast<void (*)(client_t *cl, usercmd_s *cmd)>(0x822C6F50);
 static auto SV_ClientThink = reinterpret_cast<void (*)(client_t *cl, usercmd_s *cmd)>(0x822C7D60);
+static auto SV_CalcPings = reinterpret_cast<void (*)()>(0x822CE380);
 static auto G_SelectWeapon = reinterpret_cast<G_SelectWeapon_t>(0x82272800);
 
 static auto SV_DropClient = reinterpret_cast<SV_DropClient_t>(0x822C66A8);


### PR DESCRIPTION
Add bot support to IW5

- Adds GSC method ( hacky workaround `self GetViewmodel("spawnbot", count);` )
- Update client_t struct
- Fix issue with casting svs_clients
- Update build.py to run parallel jobs

Requires Xbox Live or System Link on both Retail and Xenia. Will **NOT** work on splitscreen due to max clients