### PR TITLE
fix(iw5): make rocket jumping configurable

### DIFF
--- a/src/game/iw5/mp/events.cpp
+++ b/src/game/iw5/mp/events.cpp
@@ -6,8 +6,22 @@ namespace iw5
 namespace mp
 {
 
+std::vector<std::function<void()>> Events::com_initdvars_callbacks;
 std::vector<std::function<void(bool)>> Events::vm_shutdown_callbacks;
+Detour Events::Com_InitDvars_Detour;
 Detour Events::G_ShutdownGame_Detour;
+
+void Events::Com_InitDvars_Hook()
+{
+    Com_InitDvars_Detour.GetOriginal<Com_InitDvars_t>()();
+
+    for (auto it = com_initdvars_callbacks.begin(); it != com_initdvars_callbacks.end(); ++it)
+    {
+        (*it)();
+    }
+
+    com_initdvars_callbacks.clear();
+}
 
 void Events::G_ShutdownGame_Hook(int freeScripts)
 {
@@ -19,6 +33,11 @@ void Events::G_ShutdownGame_Hook(int freeScripts)
     }
 }
 
+void Events::OnDvarInit(const std::function<void()> &callback)
+{
+    com_initdvars_callbacks.emplace_back(callback);
+}
+
 void Events::OnVMShutdown(const std::function<void(bool)> &callback)
 {
     vm_shutdown_callbacks.emplace_back(callback);
@@ -26,13 +45,18 @@ void Events::OnVMShutdown(const std::function<void(bool)> &callback)
 
 Events::Events()
 {
+    Com_InitDvars_Detour = Detour(Com_InitDvars, Com_InitDvars_Hook);
+    Com_InitDvars_Detour.Install();
+
     G_ShutdownGame_Detour = Detour(G_ShutdownGame, G_ShutdownGame_Hook);
     G_ShutdownGame_Detour.Install();
 }
 
 Events::~Events()
 {
+    Com_InitDvars_Detour.Remove();
     G_ShutdownGame_Detour.Remove();
+    com_initdvars_callbacks.clear();
     vm_shutdown_callbacks.clear();
 }
 

--- a/src/game/iw5/mp/events.h
+++ b/src/game/iw5/mp/events.h
@@ -17,11 +17,15 @@ class Events : public Module
         return "Events";
     };
 
+    static void OnDvarInit(const std::function<void()> &callback);
     static void OnVMShutdown(const std::function<void(bool)> &callback);
 
   private:
+    static std::vector<std::function<void()>> com_initdvars_callbacks;
     static std::vector<std::function<void(bool)>> vm_shutdown_callbacks;
+    static Detour Com_InitDvars_Detour;
     static Detour G_ShutdownGame_Detour;
+    static void Com_InitDvars_Hook();
     static void G_ShutdownGame_Hook(int freeScripts);
 };
 } // namespace mp

--- a/src/game/iw5/mp/pm.cpp
+++ b/src/game/iw5/mp/pm.cpp
@@ -1,10 +1,15 @@
 #include "pch.h"
 #include "pm.h"
+#include "events.h"
 
 namespace iw5
 {
 namespace mp
 {
+namespace
+{
+dvar_t *bg_rocketJump = nullptr;
+dvar_t *bg_rocketJumpScale = nullptr;
 
 Detour Weapon_RocketLauncher_Fire_Detour;
 
@@ -12,25 +17,34 @@ gentity_s *Weapon_RocketLauncher_Fire_Hook(gentity_s *ent, const Weapon *weapon,
                                            weaponParms *gunVel, missileFireParms *fireParms,
                                            missileFireParms *magicBullet, bool a8)
 {
-    // NOTE: remove this hack and remove shellshock another way
-    // // Call the original function
-    // gentity_s *result = Weapon_RocketLauncher_Fire_Detour.GetOriginal<Weapon_RocketLauncher_Fire_t>()(
-    //     ent, weapon, spread, wp, gunVel, fireParms, magicBullet, a8);
+    auto *result = Weapon_RocketLauncher_Fire_Detour.GetOriginal<Weapon_RocketLauncher_Fire_t>()(
+        ent, weapon, spread, wp, gunVel, fireParms, magicBullet, a8);
 
     // Reimplement COD4 logic for RPG knockback
     // Apply at the end which matches the original game behavior
-    if (ent->client)
+    if (ent->client && bg_rocketJump && bg_rocketJumpScale && bg_rocketJump->current.enabled)
     {
-        ent->client->ps.velocity[0] = ent->client->ps.velocity[0] - wp->forward[0] * 64.0f;
-        ent->client->ps.velocity[1] = ent->client->ps.velocity[1] - wp->forward[1] * 64.0f;
-        ent->client->ps.velocity[2] = ent->client->ps.velocity[2] - wp->forward[2] * 64.0f;
+        const auto scale = bg_rocketJumpScale->current.value;
+        ent->client->ps.velocity[0] += (0.0f - wp->forward[0]) * scale;
+        ent->client->ps.velocity[1] += (0.0f - wp->forward[1]) * scale;
+        ent->client->ps.velocity[2] += (0.0f - wp->forward[2]) * scale;
     }
 
-    return 0;
+    return result;
 }
+} // namespace
 
 PlayerMovement::PlayerMovement()
 {
+    Events::OnDvarInit(
+        []
+        {
+            bg_rocketJump = Dvar_RegisterBool("bg_rocketJump", false, DVAR_FLAG_SERVERINFO, "Enable CoD4 rocket jumps");
+
+            bg_rocketJumpScale = Dvar_RegisterFloat("bg_rocketJumpScale", 64.0f, 1.0f, FLT_MAX, DVAR_FLAG_SERVERINFO,
+                                                    "The scale applied to the pushback force of a rocket");
+        });
+
     Weapon_RocketLauncher_Fire_Detour = Detour(Weapon_RocketLauncher_Fire, Weapon_RocketLauncher_Fire_Hook);
     Weapon_RocketLauncher_Fire_Detour.Install();
 }

--- a/src/game/iw5/mp/structs.h
+++ b/src/game/iw5/mp/structs.h
@@ -1873,6 +1873,11 @@ union DvarValue
     unsigned __int8 color[4];
 };
 
+enum DvarFlags : unsigned __int16
+{
+    DVAR_FLAG_SERVERINFO = 0x10,
+};
+
 struct dvar_t
 {
     const char *name;
@@ -1946,6 +1951,8 @@ typedef void (*CL_ConsolePrint_t)(LocalClientNum_t localClientNum, int channel, 
                                   unsigned int pixelWidth, int flags);
 typedef Font_s *(*CL_RegisterFont_t)(const char *fontName, int imageTrack);
 
+typedef void (*Com_InitDvars_t)();
+
 typedef XAssetEntry *(*DB_FindXAssetEntry_t)(XAssetType type, const char *name);
 typedef XAssetHeader *(*DB_FindXAssetHeader_t)(XAssetType type, const char *name, int allowCreateDefault);
 typedef XAssetEntry *(*DB_LinkXAssetEntry_t)(XAssetType type, XAssetHeader *header);
@@ -1953,6 +1960,10 @@ typedef const char *(*DB_GetXAssetName_t)(const XAsset *asset);
 typedef bool (*DB_IsXAssetDefault_t)(XAssetType type, const char *name);
 
 typedef dvar_t *(*Dvar_FindMalleableVar_t)(const char *dvarName);
+typedef dvar_t *(*Dvar_RegisterBool_t)(const char *dvarName, bool value, unsigned __int16 flags,
+                                       const char *description);
+typedef dvar_t *(*Dvar_RegisterFloat_t)(const char *dvarName, double value, double min, double max,
+                                        unsigned __int16 flags, const char *description);
 
 typedef void (*Jump_Start_t)(pmove_t *pm, pml_t *pml, double height);
 

--- a/src/game/iw5/mp/symbols.h
+++ b/src/game/iw5/mp/symbols.h
@@ -29,6 +29,8 @@ static auto CG_GameMessage = reinterpret_cast<CG_GameMessage_t>(0x82127BF8);
 static auto CL_ConsolePrint = reinterpret_cast<CL_ConsolePrint_t>(0x82168BB8);
 static auto CL_RegisterFont = reinterpret_cast<CL_RegisterFont_t>(0x82174F88);
 
+static auto Com_InitDvars = reinterpret_cast<Com_InitDvars_t>(0x8229FD90);
+
 static auto DB_FindXAssetEntry = reinterpret_cast<DB_FindXAssetEntry_t>(0x821EE920);
 static auto DB_FindXAssetHeader = reinterpret_cast<DB_FindXAssetHeader_t>(0x821EEBF0);
 static auto DB_GetXAssetName = reinterpret_cast<DB_GetXAssetName_t>(0x821AB560);
@@ -36,6 +38,8 @@ static auto DB_LinkXAssetEntry = reinterpret_cast<DB_LinkXAssetEntry_t>(0x821EF3
 static auto DB_IsXAssetDefault = reinterpret_cast<DB_IsXAssetDefault_t>(0x821EEEB0);
 
 static auto Dvar_FindMalleableVar = reinterpret_cast<Dvar_FindMalleableVar_t>(0x8232E100);
+static auto Dvar_RegisterBool = reinterpret_cast<Dvar_RegisterBool_t>(0x8232F4B8);
+static auto Dvar_RegisterFloat = reinterpret_cast<Dvar_RegisterFloat_t>(0x8232F540);
 
 static auto G_ShutdownGame = reinterpret_cast<G_ShutdownGame_t>(0x82244378);
 


### PR DESCRIPTION
codxe started as a codjumper mod so rocket entities were not important, this restores them and makes cod4 style rocket jumps configurable with a dvar (IW4x style).

This fixes any projectile weapons and the predator missile.

Fixes https://github.com/michaeloliverx/codxe/issues/190