### PR TITLE
refactor(clipmap): track modified brush collision with bitmaps

### DIFF
--- a/codxe.vcxproj
+++ b/codxe.vcxproj
@@ -80,6 +80,7 @@
         <PrecompiledHeader>Create</PrecompiledHeader>
       </ClCompile>
 
+      <ClCompile Include="src\common\brush_collision_tracker.cpp" />
       <ClCompile Include="src\common\config.cpp" />
 
       <ClCompile Include="src\game\ngl\mp\main.cpp" />
@@ -208,6 +209,7 @@
       <ClInclude Include="src\pch.h" />
 
       <ClInclude Include="src\common\branding.h" />
+      <ClInclude Include="src\common\brush_collision_tracker.h" />
       <ClInclude Include="src\common\config.h" />
 
       <ClInclude Include="src\game\ngl\mp\main.h" />

--- a/src/common/brush_collision_tracker.cpp
+++ b/src/common/brush_collision_tracker.cpp
@@ -1,0 +1,30 @@
+#include "pch.h"
+#include "brush_collision_tracker.h"
+
+namespace
+{
+enum
+{
+    MAX_BRUSH_COUNT = USHRT_MAX + 1,
+    BRUSHES_PER_WORD = sizeof(uint32_t) * 8,
+};
+uint32_t modifiedBrushes[MAX_BRUSH_COUNT / BRUSHES_PER_WORD];
+} // namespace
+
+namespace brush_collision_tracker
+{
+void Clear()
+{
+    memset(modifiedBrushes, 0, sizeof(modifiedBrushes));
+}
+
+void MarkModified(unsigned int index)
+{
+    modifiedBrushes[index / BRUSHES_PER_WORD] |= 1u << (index % BRUSHES_PER_WORD);
+}
+
+bool WasModified(unsigned int index)
+{
+    return (modifiedBrushes[index / BRUSHES_PER_WORD] & (1u << (index % BRUSHES_PER_WORD))) != 0;
+}
+} // namespace brush_collision_tracker

--- a/src/common/brush_collision_tracker.h
+++ b/src/common/brush_collision_tracker.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace brush_collision_tracker
+{
+void Clear();
+void MarkModified(unsigned int index);
+bool WasModified(unsigned int index);
+} // namespace brush_collision_tracker

--- a/src/game/iw3/mp/components/clipmap.cpp
+++ b/src/game/iw3/mp/components/clipmap.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "common/brush_collision_tracker.h"
 #include "events.h"
 #include "clipmap.h"
 
@@ -8,28 +9,11 @@ namespace mp
 {
 dvar_s *noclip_brushes = nullptr;
 
-enum
-{
-    MAX_BRUSH_COUNT = USHRT_MAX + 1,
-    BRUSHES_PER_WORD = sizeof(uint32_t) * 8,
-};
-static uint32_t modifiedBrushes[MAX_BRUSH_COUNT / BRUSHES_PER_WORD];
-
-void ClearModifiedBrushes()
-{
-    memset(modifiedBrushes, 0, sizeof(modifiedBrushes));
-}
-
-bool WasBrushModified(unsigned int index)
-{
-    return (modifiedBrushes[index / BRUSHES_PER_WORD] & (1u << (index % BRUSHES_PER_WORD))) != 0;
-}
-
 void RemoveBrushCollision(unsigned int index)
 {
     if (cm->brushes[index].contents & CONTENTS_PLAYERCLIP)
     {
-        modifiedBrushes[index / BRUSHES_PER_WORD] |= 1u << (index % BRUSHES_PER_WORD);
+        brush_collision_tracker::MarkModified(index);
         cm->brushes[index].contents &= ~CONTENTS_PLAYERCLIP;
     }
 }
@@ -37,17 +21,16 @@ void RemoveBrushCollision(unsigned int index)
 void RestoreBrushContents()
 {
     assert(cm->isInUse);
-    assert(static_cast<size_t>(cm->numBrushes) <= MAX_BRUSH_COUNT);
 
     for (unsigned int i = 0; i < cm->numBrushes; ++i)
     {
-        if (WasBrushModified(i))
+        if (brush_collision_tracker::WasModified(i))
         {
             cm->brushes[i].contents |= CONTENTS_PLAYERCLIP;
         }
     }
 
-    ClearModifiedBrushes();
+    brush_collision_tracker::Clear();
 }
 
 void RemoveAllBrushCollision()
@@ -112,7 +95,7 @@ clipmap::clipmap()
             noclip_brushes = Dvar_RegisterString("noclip_brushes", "", DVAR_CODINFO,
                                                  "Space separated list of brushes to disable collision on.");
         });
-    Events::OnCG_Init(ClearModifiedBrushes);
+    Events::OnCG_Init(brush_collision_tracker::Clear);
     Events::OnCG_DrawActive(clipmap::HandleBrushCollisionChange);
 }
 

--- a/src/game/iw3/mp/components/clipmap.cpp
+++ b/src/game/iw3/mp/components/clipmap.cpp
@@ -8,37 +8,55 @@ namespace mp
 {
 dvar_s *noclip_brushes = nullptr;
 
-static std::array<uint32_t, USHRT_MAX + 1> brushContents;
-
-void SaveBrushContents()
+enum
 {
-    assert(cm->isInUse);
-    assert(static_cast<size_t>(cm->numBrushes) <= brushContents.size());
+    MAX_BRUSH_COUNT = USHRT_MAX + 1,
+    BRUSHES_PER_WORD = sizeof(uint32_t) * 8,
+};
+static uint32_t modifiedBrushes[MAX_BRUSH_COUNT / BRUSHES_PER_WORD];
 
-    for (int i = 0; i < cm->numBrushes; ++i)
+void ClearModifiedBrushes()
+{
+    memset(modifiedBrushes, 0, sizeof(modifiedBrushes));
+}
+
+bool WasBrushModified(unsigned int index)
+{
+    return (modifiedBrushes[index / BRUSHES_PER_WORD] & (1u << (index % BRUSHES_PER_WORD))) != 0;
+}
+
+void RemoveBrushCollision(unsigned int index)
+{
+    if (cm->brushes[index].contents & CONTENTS_PLAYERCLIP)
     {
-        brushContents[i] = cm->brushes[i].contents;
+        modifiedBrushes[index / BRUSHES_PER_WORD] |= 1u << (index % BRUSHES_PER_WORD);
+        cm->brushes[index].contents &= ~CONTENTS_PLAYERCLIP;
     }
 }
 
 void RestoreBrushContents()
 {
     assert(cm->isInUse);
-    assert(static_cast<size_t>(cm->numBrushes) <= brushContents.size());
+    assert(static_cast<size_t>(cm->numBrushes) <= MAX_BRUSH_COUNT);
 
-    for (int i = 0; i < cm->numBrushes; ++i)
+    for (unsigned int i = 0; i < cm->numBrushes; ++i)
     {
-        cm->brushes[i].contents = brushContents[i];
+        if (WasBrushModified(i))
+        {
+            cm->brushes[i].contents |= CONTENTS_PLAYERCLIP;
+        }
     }
+
+    ClearModifiedBrushes();
 }
 
 void RemoveAllBrushCollision()
 {
     assert(cm->isInUse);
 
-    for (int i = 0; i < cm->numBrushes; ++i)
+    for (unsigned int i = 0; i < cm->numBrushes; ++i)
     {
-        cm->brushes[i].contents &= ~CONTENTS_PLAYERCLIP; // Disable collision for all brushes
+        RemoveBrushCollision(i);
     }
 }
 
@@ -80,7 +98,7 @@ void clipmap::HandleBrushCollisionChange()
                     DbgPrint("Error: Invalid brush index: %d\n", idx);
                     continue;
                 }
-                cm->brushes[idx].contents &= ~CONTENTS_PLAYERCLIP; // Disable collision
+                RemoveBrushCollision(idx);
             }
         }
     }
@@ -94,7 +112,7 @@ clipmap::clipmap()
             noclip_brushes = Dvar_RegisterString("noclip_brushes", "", DVAR_CODINFO,
                                                  "Space separated list of brushes to disable collision on.");
         });
-    Events::OnCG_Init(SaveBrushContents);
+    Events::OnCG_Init(ClearModifiedBrushes);
     Events::OnCG_DrawActive(clipmap::HandleBrushCollisionChange);
 }
 

--- a/src/game/iw4/mp_tu6/components/clipmap.cpp
+++ b/src/game/iw4/mp_tu6/components/clipmap.cpp
@@ -1,31 +1,15 @@
 #include "pch.h"
+#include "common/brush_collision_tracker.h"
 #include "clipmap.h"
 #include "events.h"
 
 iw4::mp_tu6::dvar_t *noclip_brushes = nullptr;
 
-enum
-{
-    MAX_BRUSH_COUNT = USHRT_MAX + 1,
-    BRUSHES_PER_WORD = sizeof(uint32_t) * 8,
-};
-static uint32_t modifiedBrushes[MAX_BRUSH_COUNT / BRUSHES_PER_WORD];
-
-void ClearModifiedBrushes()
-{
-    memset(modifiedBrushes, 0, sizeof(modifiedBrushes));
-}
-
-bool WasBrushModified(unsigned int index)
-{
-    return (modifiedBrushes[index / BRUSHES_PER_WORD] & (1u << (index % BRUSHES_PER_WORD))) != 0;
-}
-
 void RemoveBrushCollision(unsigned int index)
 {
     if (iw4::mp_tu6::cm->brushContents[index] & CONTENTS_PLAYERCLIP)
     {
-        modifiedBrushes[index / BRUSHES_PER_WORD] |= 1u << (index % BRUSHES_PER_WORD);
+        brush_collision_tracker::MarkModified(index);
         iw4::mp_tu6::cm->brushContents[index] &= ~CONTENTS_PLAYERCLIP;
     }
 }
@@ -48,7 +32,7 @@ iw4::mp_tu6::XAssetEntryPoolEntry *DB_LinkXAssetEntry1_Hook(iw4::mp_tu6::XAssetT
 
     if (type == iw4::mp_tu6::ASSET_TYPE_CLIPMAP_MP)
     {
-        ClearModifiedBrushes();
+        brush_collision_tracker::Clear();
     }
 
     return entry;
@@ -60,13 +44,13 @@ void RestoreBrushContents()
 
     for (unsigned int i = 0; i < iw4::mp_tu6::cm->numBrushes; ++i)
     {
-        if (WasBrushModified(i))
+        if (brush_collision_tracker::WasModified(i))
         {
             iw4::mp_tu6::cm->brushContents[i] |= CONTENTS_PLAYERCLIP;
         }
     }
 
-    ClearModifiedBrushes();
+    brush_collision_tracker::Clear();
 }
 
 void RemoveAllBrushCollision()

--- a/src/game/iw4/mp_tu6/components/clipmap.cpp
+++ b/src/game/iw4/mp_tu6/components/clipmap.cpp
@@ -3,7 +3,32 @@
 #include "events.h"
 
 iw4::mp_tu6::dvar_t *noclip_brushes = nullptr;
-std::vector<int> original_brush_contents;
+
+enum
+{
+    MAX_BRUSH_COUNT = USHRT_MAX + 1,
+    BRUSHES_PER_WORD = sizeof(uint32_t) * 8,
+};
+static uint32_t modifiedBrushes[MAX_BRUSH_COUNT / BRUSHES_PER_WORD];
+
+void ClearModifiedBrushes()
+{
+    memset(modifiedBrushes, 0, sizeof(modifiedBrushes));
+}
+
+bool WasBrushModified(unsigned int index)
+{
+    return (modifiedBrushes[index / BRUSHES_PER_WORD] & (1u << (index % BRUSHES_PER_WORD))) != 0;
+}
+
+void RemoveBrushCollision(unsigned int index)
+{
+    if (iw4::mp_tu6::cm->brushContents[index] & CONTENTS_PLAYERCLIP)
+    {
+        modifiedBrushes[index / BRUSHES_PER_WORD] |= 1u << (index % BRUSHES_PER_WORD);
+        iw4::mp_tu6::cm->brushContents[index] &= ~CONTENTS_PLAYERCLIP;
+    }
+}
 
 Detour DB_LinkXAssetEntry1_Detour;
 
@@ -23,15 +48,7 @@ iw4::mp_tu6::XAssetEntryPoolEntry *DB_LinkXAssetEntry1_Hook(iw4::mp_tu6::XAssetT
 
     if (type == iw4::mp_tu6::ASSET_TYPE_CLIPMAP_MP)
     {
-        // Resize the vector to match the number of brushes
-        original_brush_contents.resize(header->clipMap->numBrushes);
-
-        // Save original contents
-        for (int i = 0; i < header->clipMap->numBrushes; ++i)
-        {
-            original_brush_contents[i] =
-                header->clipMap->brushContents[i]; // Assuming this is the field you want to save
-        }
+        ClearModifiedBrushes();
     }
 
     return entry;
@@ -40,23 +57,25 @@ iw4::mp_tu6::XAssetEntryPoolEntry *DB_LinkXAssetEntry1_Hook(iw4::mp_tu6::XAssetT
 void RestoreBrushContents()
 {
     assert(iw4::mp_tu6::cm->isInUse);
-    assert(original_brush_contents.size() == static_cast<size_t>(iw4::mp_tu6::cm->numBrushes));
 
-    // Restore original contents
-    for (int i = 0; i < iw4::mp_tu6::cm->numBrushes; ++i)
+    for (unsigned int i = 0; i < iw4::mp_tu6::cm->numBrushes; ++i)
     {
-        iw4::mp_tu6::cm->brushContents[i] = original_brush_contents[i];
+        if (WasBrushModified(i))
+        {
+            iw4::mp_tu6::cm->brushContents[i] |= CONTENTS_PLAYERCLIP;
+        }
     }
+
+    ClearModifiedBrushes();
 }
 
 void RemoveAllBrushCollision()
 {
     assert(iw4::mp_tu6::cm->isInUse);
-    assert(original_brush_contents.size() == static_cast<size_t>(iw4::mp_tu6::cm->numBrushes));
 
-    for (int i = 0; i < iw4::mp_tu6::cm->numBrushes; ++i)
+    for (unsigned int i = 0; i < iw4::mp_tu6::cm->numBrushes; ++i)
     {
-        iw4::mp_tu6::cm->brushContents[i] &= ~CONTENTS_PLAYERCLIP; // Disable player collision
+        RemoveBrushCollision(i);
     }
 }
 
@@ -141,7 +160,6 @@ clipmap::clipmap()
             if (iw4::mp_tu6::R_CheckDvarModified(noclip_brushes))
             {
                 assert(iw4::mp_tu6::cm->isInUse);
-                assert(original_brush_contents.size() == static_cast<size_t>(iw4::mp_tu6::cm->numBrushes));
 
                 std::string value = noclip_brushes->current.string;
 
@@ -166,7 +184,7 @@ clipmap::clipmap()
                                 0, iw4::mp_tu6::va("^1Error: Invalid brush index %d for map", idx));
                             continue;
                         }
-                        iw4::mp_tu6::cm->brushContents[idx] &= ~CONTENTS_PLAYERCLIP;
+                        RemoveBrushCollision(idx);
                     }
                 }
             }

--- a/src/game/qos/mp/components/clipmap.cpp
+++ b/src/game/qos/mp/components/clipmap.cpp
@@ -10,17 +10,30 @@ namespace mp
 {
 
 dvar_s *clipmap::noclip_brushes;
-std::vector<int> clipmap::brushContents;
 
-void clipmap::SaveBrushContents()
+enum
 {
-    if (!cm->isInUse)
-        return;
+    MAX_BRUSH_COUNT = USHRT_MAX + 1,
+    BRUSHES_PER_WORD = sizeof(uint32_t) * 8,
+};
+static uint32_t modifiedBrushes[MAX_BRUSH_COUNT / BRUSHES_PER_WORD];
 
-    brushContents.resize(cm->numBrushes, 0);
-    for (int i = 0; i < cm->numBrushes; ++i)
+void ClearModifiedBrushes()
+{
+    memset(modifiedBrushes, 0, sizeof(modifiedBrushes));
+}
+
+bool WasBrushModified(unsigned int index)
+{
+    return (modifiedBrushes[index / BRUSHES_PER_WORD] & (1u << (index % BRUSHES_PER_WORD))) != 0;
+}
+
+void RemoveBrushCollision(unsigned int index)
+{
+    if (cm->brushes[index].contents & SURFACE_FLAG_PLAYERCLIP)
     {
-        brushContents[i] = cm->brushes[i].contents;
+        modifiedBrushes[index / BRUSHES_PER_WORD] |= 1u << (index % BRUSHES_PER_WORD);
+        cm->brushes[index].contents &= ~SURFACE_FLAG_PLAYERCLIP;
     }
 }
 
@@ -29,17 +42,15 @@ void clipmap::RestoreBrushContents()
     if (!cm->isInUse)
         return;
 
-    if (brushContents.size() != static_cast<size_t>(cm->numBrushes))
+    for (unsigned int i = 0; i < cm->numBrushes; ++i)
     {
-        DbgPrint("RestoreBrushContents: size mismatch - saved: %u, current: %d\n",
-                 static_cast<unsigned int>(brushContents.size()), cm->numBrushes);
-        return;
+        if (WasBrushModified(i))
+        {
+            cm->brushes[i].contents |= SURFACE_FLAG_PLAYERCLIP;
+        }
     }
 
-    for (int i = 0; i < cm->numBrushes; ++i)
-    {
-        cm->brushes[i].contents = brushContents[i];
-    }
+    ClearModifiedBrushes();
 }
 
 void clipmap::RemoveAllBrushesContents()
@@ -47,9 +58,9 @@ void clipmap::RemoveAllBrushesContents()
     if (!cm->isInUse)
         return;
 
-    for (int i = 0; i < cm->numBrushes; ++i)
+    for (unsigned int i = 0; i < cm->numBrushes; ++i)
     {
-        cm->brushes[i].contents &= ~SURFACE_FLAG_PLAYERCLIP;
+        RemoveBrushCollision(i);
     }
 }
 
@@ -75,9 +86,9 @@ void clipmap::RebuildNoclipBrushesDvar()
     std::ostringstream oss;
     bool first = true;
 
-    for (int i = 0; i < cm->numBrushes; ++i)
+    for (unsigned int i = 0; i < cm->numBrushes; ++i)
     {
-        if ((brushContents[i] & SURFACE_FLAG_PLAYERCLIP) && !(cm->brushes[i].contents & SURFACE_FLAG_PLAYERCLIP))
+        if (WasBrushModified(i))
         {
             if (!first)
                 oss << " ";
@@ -115,7 +126,7 @@ void clipmap::HandleclipmapChange()
                 DbgPrint("[clipmap] Error: Invalid brush index: %d\n", idx);
                 continue;
             }
-            cm->brushes[idx].contents &= ~SURFACE_FLAG_PLAYERCLIP;
+            RemoveBrushCollision(idx);
         }
     }
 }
@@ -152,7 +163,7 @@ void clipmap::PlayerCmd_DisablePlayerClipOnTouchingBrushes(scr_entref_t entref)
         }
 
         if (intersects)
-            brush->contents &= ~SURFACE_FLAG_PLAYERCLIP;
+            RemoveBrushCollision(i);
     }
 
     RebuildNoclipBrushesDvar();
@@ -165,7 +176,7 @@ clipmap::clipmap()
         []()
         {
             clipmap::RegisterDvars();
-            SaveBrushContents();
+            ClearModifiedBrushes();
         });
 
     Events::OnCG_DrawActive(

--- a/src/game/qos/mp/components/clipmap.cpp
+++ b/src/game/qos/mp/components/clipmap.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "common/brush_collision_tracker.h"
 #include "events.h"
 #include "clipmap.h"
 
@@ -11,28 +12,11 @@ namespace mp
 
 dvar_s *clipmap::noclip_brushes;
 
-enum
-{
-    MAX_BRUSH_COUNT = USHRT_MAX + 1,
-    BRUSHES_PER_WORD = sizeof(uint32_t) * 8,
-};
-static uint32_t modifiedBrushes[MAX_BRUSH_COUNT / BRUSHES_PER_WORD];
-
-void ClearModifiedBrushes()
-{
-    memset(modifiedBrushes, 0, sizeof(modifiedBrushes));
-}
-
-bool WasBrushModified(unsigned int index)
-{
-    return (modifiedBrushes[index / BRUSHES_PER_WORD] & (1u << (index % BRUSHES_PER_WORD))) != 0;
-}
-
 void RemoveBrushCollision(unsigned int index)
 {
     if (cm->brushes[index].contents & SURFACE_FLAG_PLAYERCLIP)
     {
-        modifiedBrushes[index / BRUSHES_PER_WORD] |= 1u << (index % BRUSHES_PER_WORD);
+        brush_collision_tracker::MarkModified(index);
         cm->brushes[index].contents &= ~SURFACE_FLAG_PLAYERCLIP;
     }
 }
@@ -44,13 +28,13 @@ void clipmap::RestoreBrushContents()
 
     for (unsigned int i = 0; i < cm->numBrushes; ++i)
     {
-        if (WasBrushModified(i))
+        if (brush_collision_tracker::WasModified(i))
         {
             cm->brushes[i].contents |= SURFACE_FLAG_PLAYERCLIP;
         }
     }
 
-    ClearModifiedBrushes();
+    brush_collision_tracker::Clear();
 }
 
 void clipmap::RemoveAllBrushesContents()
@@ -88,7 +72,7 @@ void clipmap::RebuildNoclipBrushesDvar()
 
     for (unsigned int i = 0; i < cm->numBrushes; ++i)
     {
-        if (WasBrushModified(i))
+        if (brush_collision_tracker::WasModified(i))
         {
             if (!first)
                 oss << " ";
@@ -176,7 +160,7 @@ clipmap::clipmap()
         []()
         {
             clipmap::RegisterDvars();
-            ClearModifiedBrushes();
+            brush_collision_tracker::Clear();
         });
 
     Events::OnCG_DrawActive(

--- a/src/game/qos/mp/components/clipmap.h
+++ b/src/game/qos/mp/components/clipmap.h
@@ -21,10 +21,8 @@ class clipmap : public Module
 
   private:
     static dvar_s *noclip_brushes;
-    static std::vector<int> brushContents;
 
     static void RegisterDvars();
-    static void SaveBrushContents();
     static void RestoreBrushContents();
     static void RemoveAllBrushesContents();
     static std::vector<int> ParseSpaceSeparatedInts(const std::string &str);

--- a/src/game/t4/mp/components/brush_collision.cpp
+++ b/src/game/t4/mp/components/brush_collision.cpp
@@ -7,20 +7,30 @@ namespace t4
 namespace mp
 {
 dvar_s *noclip_brushes = nullptr;
-std::vector<int> brushContents;
 
-void SaveBrushContents()
+enum
 {
-    if (!cm->isInUse)
-    {
-        DbgPrint("SaveBrushContents: cm is not in use\n");
-        return;
-    }
+    MAX_BRUSH_COUNT = USHRT_MAX + 1,
+    BRUSHES_PER_WORD = sizeof(uint32_t) * 8,
+};
+static uint32_t modifiedBrushes[MAX_BRUSH_COUNT / BRUSHES_PER_WORD];
 
-    brushContents.resize(cm->numBrushes, 0);
-    for (int i = 0; i < cm->numBrushes; ++i)
+void ClearModifiedBrushes()
+{
+    memset(modifiedBrushes, 0, sizeof(modifiedBrushes));
+}
+
+bool WasBrushModified(unsigned int index)
+{
+    return (modifiedBrushes[index / BRUSHES_PER_WORD] & (1u << (index % BRUSHES_PER_WORD))) != 0;
+}
+
+void RemoveBrushCollision(unsigned int index)
+{
+    if (cm->brushes[index].contents & 0x10000)
     {
-        brushContents[i] = cm->brushes[i].contents;
+        modifiedBrushes[index / BRUSHES_PER_WORD] |= 1u << (index % BRUSHES_PER_WORD);
+        cm->brushes[index].contents &= ~0x10000;
     }
 }
 
@@ -32,17 +42,15 @@ void RestoreBrushContents()
         return;
     }
 
-    if (brushContents.size() != static_cast<size_t>(cm->numBrushes))
+    for (unsigned int i = 0; i < cm->numBrushes; ++i)
     {
-        DbgPrint("RestoreBrushContents: size mismatch - saved: %zu, current: %d\n", brushContents.size(),
-                 cm->numBrushes);
-        return;
+        if (WasBrushModified(i))
+        {
+            cm->brushes[i].contents |= 0x10000;
+        }
     }
 
-    for (int i = 0; i < cm->numBrushes; ++i)
-    {
-        cm->brushes[i].contents = brushContents[i];
-    }
+    ClearModifiedBrushes();
 }
 
 void RemoveAllBrushCollision()
@@ -53,9 +61,9 @@ void RemoveAllBrushCollision()
         return;
     }
 
-    for (int i = 0; i < cm->numBrushes; ++i)
+    for (unsigned int i = 0; i < cm->numBrushes; ++i)
     {
-        cm->brushes[i].contents &= ~0x10000; // Disable collision for all brushes
+        RemoveBrushCollision(i);
     }
 }
 
@@ -65,8 +73,7 @@ void CM_LoadMap_Hook(const char *name)
     // Let the clip map load first
     CM_LoadMap_Detour.GetOriginal<decltype(CM_LoadMap)>()(name);
 
-    // Save the contents of the brushes
-    SaveBrushContents();
+    ClearModifiedBrushes();
 }
 
 std::vector<int> ParseSpaceSeparatedInts(const std::string &str)
@@ -114,7 +121,7 @@ void HandleBrushCollisionChange()
                     DbgPrint("Error: Invalid brush index: %d\n", idx);
                     continue;
                 }
-                cm->brushes[idx].contents &= ~0x10000; // Disable collision
+                RemoveBrushCollision(idx);
             }
         }
     }

--- a/src/game/t4/mp/components/brush_collision.cpp
+++ b/src/game/t4/mp/components/brush_collision.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "common/brush_collision_tracker.h"
 #include "brush_collision.h"
 #include "events.h"
 
@@ -8,28 +9,11 @@ namespace mp
 {
 dvar_s *noclip_brushes = nullptr;
 
-enum
-{
-    MAX_BRUSH_COUNT = USHRT_MAX + 1,
-    BRUSHES_PER_WORD = sizeof(uint32_t) * 8,
-};
-static uint32_t modifiedBrushes[MAX_BRUSH_COUNT / BRUSHES_PER_WORD];
-
-void ClearModifiedBrushes()
-{
-    memset(modifiedBrushes, 0, sizeof(modifiedBrushes));
-}
-
-bool WasBrushModified(unsigned int index)
-{
-    return (modifiedBrushes[index / BRUSHES_PER_WORD] & (1u << (index % BRUSHES_PER_WORD))) != 0;
-}
-
 void RemoveBrushCollision(unsigned int index)
 {
     if (cm->brushes[index].contents & 0x10000)
     {
-        modifiedBrushes[index / BRUSHES_PER_WORD] |= 1u << (index % BRUSHES_PER_WORD);
+        brush_collision_tracker::MarkModified(index);
         cm->brushes[index].contents &= ~0x10000;
     }
 }
@@ -44,13 +28,13 @@ void RestoreBrushContents()
 
     for (unsigned int i = 0; i < cm->numBrushes; ++i)
     {
-        if (WasBrushModified(i))
+        if (brush_collision_tracker::WasModified(i))
         {
             cm->brushes[i].contents |= 0x10000;
         }
     }
 
-    ClearModifiedBrushes();
+    brush_collision_tracker::Clear();
 }
 
 void RemoveAllBrushCollision()
@@ -73,7 +57,7 @@ void CM_LoadMap_Hook(const char *name)
     // Let the clip map load first
     CM_LoadMap_Detour.GetOriginal<decltype(CM_LoadMap)>()(name);
 
-    ClearModifiedBrushes();
+    brush_collision_tracker::Clear();
 }
 
 std::vector<int> ParseSpaceSeparatedInts(const std::string &str)


### PR DESCRIPTION
This reduces the .bss size by `248.03` KiB