### PR TITLE
refactor: replace event registry with static handlers

### DIFF
--- a/src/game/iw4/mp/components/events.cpp
+++ b/src/game/iw4/mp/components/events.cpp
@@ -1,28 +1,31 @@
 #include "pch.h"
 #include "events.h"
 
+#include "pm.h"
+
 namespace iw4
 {
 namespace mp
 {
-std::vector<std::function<void()>> Events::com_initdvars_callbacks;
+namespace
+{
+typedef void (*EventHandler)();
+
+const EventHandler dvarInitHandlers[] = {
+    pm::OnDvarInit,
+};
+} // namespace
+
 Detour Events::Com_InitDvars_Detour;
 
 void Events::Com_InitDvars_Hook()
 {
     Com_InitDvars_Detour.GetOriginal<Com_InitDvars_t>()();
 
-    for (auto it = com_initdvars_callbacks.begin(); it != com_initdvars_callbacks.end(); ++it)
+    for (size_t i = 0; i < ARRAYSIZE(dvarInitHandlers); ++i)
     {
-        (*it)();
+        dvarInitHandlers[i]();
     }
-
-    com_initdvars_callbacks.clear();
-}
-
-void Events::OnDvarInit(const std::function<void()> &callback)
-{
-    com_initdvars_callbacks.emplace_back(callback);
 }
 
 Events::Events()
@@ -34,7 +37,6 @@ Events::Events()
 Events::~Events()
 {
     Com_InitDvars_Detour.Remove();
-    com_initdvars_callbacks.clear();
 }
 } // namespace mp
 } // namespace iw4

--- a/src/game/iw4/mp/components/events.h
+++ b/src/game/iw4/mp/components/events.h
@@ -13,10 +13,7 @@ class Events : public Module
     Events();
     ~Events();
 
-    static void OnDvarInit(const std::function<void()> &callback);
-
   private:
-    static std::vector<std::function<void()>> com_initdvars_callbacks;
     static Detour Com_InitDvars_Detour;
     static void Com_InitDvars_Hook();
 };

--- a/src/game/iw4/mp/components/pm.cpp
+++ b/src/game/iw4/mp/components/pm.cpp
@@ -1,6 +1,5 @@
 #include "pch.h"
 #include "pm.h"
-#include "events.h"
 
 namespace iw4
 {
@@ -33,18 +32,17 @@ gentity_s *Weapon_RocketLauncher_Fire_Hook(gentity_s *ent, unsigned int weaponIn
 }
 
 } // namespace
+
+void pm::OnDvarInit()
+{
+    bg_rocketJump = Dvar_RegisterBool("bg_rocketJump", false, DVAR_FLAG_SERVERINFO, "Enable CoD4 rocket jumps");
+
+    bg_rocketJumpScale = Dvar_RegisterFloat("bg_rocketJumpScale", 64.0f, 1.0f, FLT_MAX, DVAR_FLAG_SERVERINFO,
+                                            "The scale applied to the pushback force of a rocket");
+}
+
 pm::pm()
 {
-
-    Events::OnDvarInit(
-        []
-        {
-            bg_rocketJump = Dvar_RegisterBool("bg_rocketJump", false, DVAR_FLAG_SERVERINFO, "Enable CoD4 rocket jumps");
-
-            bg_rocketJumpScale = Dvar_RegisterFloat("bg_rocketJumpScale", 64.0f, 1.0f, FLT_MAX, DVAR_FLAG_SERVERINFO,
-                                                    "The scale applied to the pushback force of a rocket");
-        });
-
     Weapon_RocketLauncher_Fire_Detour = Detour(Weapon_RocketLauncher_Fire, Weapon_RocketLauncher_Fire_Hook);
     Weapon_RocketLauncher_Fire_Detour.Install();
 }

--- a/src/game/iw4/mp/components/pm.h
+++ b/src/game/iw4/mp/components/pm.h
@@ -12,6 +12,8 @@ class pm : public Module
   public:
     pm();
     ~pm();
+
+    static void OnDvarInit();
 };
 } // namespace mp
 } // namespace iw4

--- a/src/game/iw4/mp_tu6/components/clipmap.cpp
+++ b/src/game/iw4/mp_tu6/components/clipmap.cpp
@@ -1,7 +1,6 @@
 #include "pch.h"
 #include "common/brush_collision_tracker.h"
 #include "clipmap.h"
-#include "events.h"
 
 iw4::mp_tu6::dvar_t *noclip_brushes = nullptr;
 
@@ -133,46 +132,45 @@ void DisablePlayerClipOnIntersectingBrushes(iw4::mp_tu6::scr_entref_t entref)
     iw4::mp_tu6::CG_GameMessage(0, iw4::mp_tu6::va("^2Disabled collision for brushes: %s", new_value.c_str()));
 }
 
+void clipmap::OnCGDrawActive()
+{
+    if (iw4::mp_tu6::R_CheckDvarModified(noclip_brushes))
+    {
+        assert(iw4::mp_tu6::cm->isInUse);
+
+        std::string value = noclip_brushes->current.string;
+
+        if (value == "")
+        {
+            RestoreBrushContents();
+        }
+        else if (value == "*")
+        {
+            RemoveAllBrushCollision();
+        }
+        else
+        {
+            RestoreBrushContents();
+            const auto brush_indices = ParseSpaceSeparatedInts(value);
+            for (size_t i = 0; i < brush_indices.size(); ++i)
+            {
+                const int idx = brush_indices[i];
+                if (idx < 0 || idx >= iw4::mp_tu6::cm->numBrushes)
+                {
+                    iw4::mp_tu6::CG_GameMessage(0,
+                                                iw4::mp_tu6::va("^1Error: Invalid brush index %d for map", idx));
+                    continue;
+                }
+                RemoveBrushCollision(idx);
+            }
+        }
+    }
+}
+
 clipmap::clipmap()
 {
     DB_LinkXAssetEntry1_Detour = Detour(iw4::mp_tu6::DB_LinkXAssetEntry1, DB_LinkXAssetEntry1_Hook);
     DB_LinkXAssetEntry1_Detour.Install();
-
-    Events::OnCG_DrawActive(
-        []()
-        {
-            if (iw4::mp_tu6::R_CheckDvarModified(noclip_brushes))
-            {
-                assert(iw4::mp_tu6::cm->isInUse);
-
-                std::string value = noclip_brushes->current.string;
-
-                if (value == "")
-                {
-                    RestoreBrushContents();
-                }
-                else if (value == "*")
-                {
-                    RemoveAllBrushCollision();
-                }
-                else
-                {
-                    RestoreBrushContents();
-                    const auto brush_indices = ParseSpaceSeparatedInts(value);
-                    for (size_t i = 0; i < brush_indices.size(); ++i)
-                    {
-                        const int idx = brush_indices[i];
-                        if (idx < 0 || idx >= iw4::mp_tu6::cm->numBrushes)
-                        {
-                            iw4::mp_tu6::CG_GameMessage(
-                                0, iw4::mp_tu6::va("^1Error: Invalid brush index %d for map", idx));
-                            continue;
-                        }
-                        RemoveBrushCollision(idx);
-                    }
-                }
-            }
-        });
 }
 
 clipmap::~clipmap()

--- a/src/game/iw4/mp_tu6/components/clipmap.cpp
+++ b/src/game/iw4/mp_tu6/components/clipmap.cpp
@@ -157,8 +157,7 @@ void clipmap::OnCGDrawActive()
                 const int idx = brush_indices[i];
                 if (idx < 0 || idx >= iw4::mp_tu6::cm->numBrushes)
                 {
-                    iw4::mp_tu6::CG_GameMessage(0,
-                                                iw4::mp_tu6::va("^1Error: Invalid brush index %d for map", idx));
+                    iw4::mp_tu6::CG_GameMessage(0, iw4::mp_tu6::va("^1Error: Invalid brush index %d for map", idx));
                     continue;
                 }
                 RemoveBrushCollision(idx);

--- a/src/game/iw4/mp_tu6/components/clipmap.h
+++ b/src/game/iw4/mp_tu6/components/clipmap.h
@@ -7,6 +7,8 @@ class clipmap : public Module
   public:
     clipmap();
     ~clipmap();
+
+    static void OnCGDrawActive();
 };
 
 void DisablePlayerClipOnIntersectingBrushes(iw4::mp_tu6::scr_entref_t entref);

--- a/src/game/iw4/mp_tu6/components/console.cpp
+++ b/src/game/iw4/mp_tu6/components/console.cpp
@@ -1,6 +1,5 @@
 #include "pch.h"
 #include "console.h"
-#include "events.h"
 
 namespace
 {
@@ -266,10 +265,13 @@ void dispatch_keystroke(const XINPUT_KEYSTROKE &keystroke)
 
 Detour console::SCR_DrawScreenField_Detour;
 
+void console::OnCmdInit()
+{
+    register_commands();
+}
+
 console::console()
 {
-    Events::OnCmdInit(register_commands);
-
     SCR_DrawScreenField_Detour = Detour(iw4::mp_tu6::SCR_DrawScreenField, SCR_DrawScreenField_Hook);
     SCR_DrawScreenField_Detour.Install();
 }

--- a/src/game/iw4/mp_tu6/components/console.h
+++ b/src/game/iw4/mp_tu6/components/console.h
@@ -8,6 +8,8 @@ class console : public Module
     console();
     ~console();
 
+    static void OnCmdInit();
+
   private:
     static Detour SCR_DrawScreenField_Detour;
     static void SCR_DrawScreenField_Hook(int localClientNum, int refreshedUI);

--- a/src/game/iw4/mp_tu6/components/events.cpp
+++ b/src/game/iw4/mp_tu6/components/events.cpp
@@ -1,83 +1,85 @@
 #include "pch.h"
 #include "events.h"
 
-std::vector<std::function<void()>> Events::com_initdvars_callbacks;
+#include "clipmap.h"
+#include "console.h"
+#include "gsc.h"
+#include "mr.h"
+#include "pm.h"
+#include "stats.h"
+#include "sv_bots.h"
+
+namespace
+{
+typedef void (*EventHandler)();
+
+const EventHandler dvarInitHandlers[] = {
+    iw4::mp_tu6::pm::OnDvarInit,
+};
+
+const EventHandler cgDrawActiveHandlers[] = {
+    clipmap::OnCGDrawActive,
+    iw4::mp_tu6::MovementRecorder::OnCGDrawActive,
+};
+
+const EventHandler cmdInitHandlers[] = {
+    console::OnCmdInit,
+    iw4::mp_tu6::MovementRecorder::OnCmdInit,
+    iw4::mp_tu6::stats::OnCmdInit,
+};
+
+const EventHandler vmShutdownHandlers[] = {
+    iw4::mp_tu6::GSC::OnVMShutdown,
+    iw4::mp_tu6::SVBots::OnVMShutdown,
+};
+} // namespace
+
 Detour Events::Com_InitDvars_Detour;
 
 void Events::Com_InitDvars_Hook()
 {
     Com_InitDvars_Detour.GetOriginal<decltype(iw4::mp_tu6::Com_InitDvars)>()();
 
-    for (auto it = com_initdvars_callbacks.begin(); it != com_initdvars_callbacks.end(); ++it)
+    for (size_t i = 0; i < ARRAYSIZE(dvarInitHandlers); ++i)
     {
-        (*it)();
+        dvarInitHandlers[i]();
     }
-
-    com_initdvars_callbacks.clear();
 }
-
-void Events::OnDvarInit(const std::function<void()> &callback)
-{
-    com_initdvars_callbacks.emplace_back(callback);
-}
-
-std::vector<std::function<void()>> Events::cg_drawactive_callbacks;
 
 void Events::CG_DrawActive_Hook(int localClientNum)
 {
     // Call original function first
     CG_DrawActive_Detour.GetOriginal<decltype(&CG_DrawActive_Hook)>()(localClientNum);
 
-    for (auto it = cg_drawactive_callbacks.begin(); it != cg_drawactive_callbacks.end(); ++it)
+    for (size_t i = 0; i < ARRAYSIZE(cgDrawActiveHandlers); ++i)
     {
-        (*it)();
+        cgDrawActiveHandlers[i]();
     }
 }
 
-void Events::OnCG_DrawActive(const std::function<void()> &callback)
-{
-    cg_drawactive_callbacks.emplace_back(callback);
-}
-
 Detour Events::CG_DrawActive_Detour;
-
-std::vector<std::function<void()>> Events::cmdinit_callbacks;
 
 void Events::Cmd_Init_Hook()
 {
     // Call original function first so the command subsystem is ready.
     Cmd_Init_Detour.GetOriginal<decltype(iw4::mp_tu6::Cmd_Init)>()();
 
-    for (auto it = cmdinit_callbacks.begin(); it != cmdinit_callbacks.end(); ++it)
+    for (size_t i = 0; i < ARRAYSIZE(cmdInitHandlers); ++i)
     {
-        (*it)();
+        cmdInitHandlers[i]();
     }
-
-    cmdinit_callbacks.clear();
-}
-
-void Events::OnCmdInit(const std::function<void()> &callback)
-{
-    cmdinit_callbacks.emplace_back(callback);
 }
 
 Detour Events::Cmd_Init_Detour;
 
-std::vector<std::function<void()>> Events::vmshutdown_callbacks;
-
 void Events::Scr_ShutdownSystem_Hook(unsigned __int8 sys)
 {
-    for (auto it = vmshutdown_callbacks.begin(); it != vmshutdown_callbacks.end(); ++it)
+    for (size_t i = 0; i < ARRAYSIZE(vmShutdownHandlers); ++i)
     {
-        (*it)();
+        vmShutdownHandlers[i]();
     }
 
     Scr_ShutdownSystem_Detour.GetOriginal<iw4::mp_tu6::Scr_ShutdownSystem_t>()(sys);
-}
-
-void Events::OnVMShutdown(const std::function<void()> &callback)
-{
-    vmshutdown_callbacks.emplace_back(callback);
 }
 
 Detour Events::Scr_ShutdownSystem_Detour;
@@ -103,9 +105,4 @@ Events::~Events()
     CG_DrawActive_Detour.Remove();
     Cmd_Init_Detour.Remove();
     Scr_ShutdownSystem_Detour.Remove();
-
-    com_initdvars_callbacks.clear();
-    cg_drawactive_callbacks.clear();
-    cmdinit_callbacks.clear();
-    vmshutdown_callbacks.clear();
 }

--- a/src/game/iw4/mp_tu6/components/events.h
+++ b/src/game/iw4/mp_tu6/components/events.h
@@ -8,25 +8,16 @@ class Events : public Module
     Events();
     ~Events();
 
-    static void OnDvarInit(const std::function<void()> &callback);
-    static void OnCG_DrawActive(const std::function<void()> &callback);
-    static void OnCmdInit(const std::function<void()> &callback);
-    static void OnVMShutdown(const std::function<void()> &callback);
-
   private:
-    static std::vector<std::function<void()>> com_initdvars_callbacks;
     static Detour Com_InitDvars_Detour;
     static void Com_InitDvars_Hook();
 
-    static std::vector<std::function<void()>> cg_drawactive_callbacks;
     static Detour CG_DrawActive_Detour;
     static void CG_DrawActive_Hook(int localClientNum);
 
-    static std::vector<std::function<void()>> cmdinit_callbacks;
     static Detour Cmd_Init_Detour;
     static void Cmd_Init_Hook();
 
-    static std::vector<std::function<void()>> vmshutdown_callbacks;
     static Detour Scr_ShutdownSystem_Detour;
     static void Scr_ShutdownSystem_Hook(unsigned __int8 sys);
 };

--- a/src/game/iw4/mp_tu6/components/gsc.cpp
+++ b/src/game/iw4/mp_tu6/components/gsc.cpp
@@ -2,7 +2,6 @@
 #include "gsc.h"
 #include "common/gsc_registry.h"
 #include "clipmap.h"
-#include "events.h"
 #include "sv_bots.h"
 
 namespace iw4
@@ -299,6 +298,11 @@ static void CloseScriptIOFile()
     }
 }
 
+void GSC::OnVMShutdown()
+{
+    CloseScriptIOFile();
+}
+
 static void GScr_CloseFile()
 {
     if (Scr_GetNumParam() != 0)
@@ -322,8 +326,6 @@ GSC::GSC()
 
     Scr_GetMethod_Detour = Detour(Scr_GetMethod, Scr_GetMethod_Hook);
     Scr_GetMethod_Detour.Install();
-
-    Events::OnVMShutdown(CloseScriptIOFile);
 }
 
 GSC::~GSC()

--- a/src/game/iw4/mp_tu6/components/gsc.h
+++ b/src/game/iw4/mp_tu6/components/gsc.h
@@ -11,6 +11,8 @@ class GSC : public Module
   public:
     GSC();
     ~GSC();
+
+    static void OnVMShutdown();
 };
 } // namespace mp_tu6
 } // namespace iw4

--- a/src/game/iw4/mp_tu6/components/mr.cpp
+++ b/src/game/iw4/mp_tu6/components/mr.cpp
@@ -1,6 +1,5 @@
 #include "pch.h"
 #include "mr.h"
-#include "events.h"
 
 #define ANGLE2SHORT(x) ((int)((x) * 65536 / 360) & 65535)
 #define SHORT2ANGLE(x) ((x) * (360.0 / 65536))
@@ -231,30 +230,28 @@ void CL_CreateNewCommands_Hook(int localClientNum)
 
 const float color_white_rgba[4] = {1.0f, 1.0f, 1.0f, 1.0f};
 
+void MovementRecorder::OnCmdInit()
+{
+    Cmd_AddCommandInternal("startrecord", Cmd_Startrecord_f, &Cmd_Startrecord_VAR);
+    Cmd_AddCommandInternal("stoprecord", Cmd_Stoprecord_f, &Cmd_Stoprecord_VAR);
+    Cmd_AddCommandInternal("togglerecord", Cmd_Togglerecord_f, &Cmd_Togglerecord_VAR);
+    Cmd_AddCommandInternal("startplayback", Cmd_Startplayback_f, &Cmd_Startplayback_VAR);
+    Cmd_AddCommandInternal("stopplayback", Cmd_Stopplayback_f, &Cmd_Stopplayback_VAR);
+}
+
+void MovementRecorder::OnCGDrawActive()
+{
+    if (is_playing)
+    {
+        static auto bigDevFont = iw4::mp_tu6::R_RegisterFont("fonts/bigDevFont");
+        iw4::mp_tu6::R_AddCmdDrawText("TAS", 4, bigDevFont, 10.f, 20.f, 1.0f, 1.0f, 0.0f, color_white_rgba, 0);
+    }
+}
+
 MovementRecorder::MovementRecorder()
 {
     CL_CreateNewCommands_Detour = Detour(CL_CreateNewCommands, CL_CreateNewCommands_Hook);
     CL_CreateNewCommands_Detour.Install();
-
-    Events::OnCmdInit(
-        []
-        {
-            Cmd_AddCommandInternal("startrecord", Cmd_Startrecord_f, &Cmd_Startrecord_VAR);
-            Cmd_AddCommandInternal("stoprecord", Cmd_Stoprecord_f, &Cmd_Stoprecord_VAR);
-            Cmd_AddCommandInternal("togglerecord", Cmd_Togglerecord_f, &Cmd_Togglerecord_VAR);
-            Cmd_AddCommandInternal("startplayback", Cmd_Startplayback_f, &Cmd_Startplayback_VAR);
-            Cmd_AddCommandInternal("stopplayback", Cmd_Stopplayback_f, &Cmd_Stopplayback_VAR);
-        });
-
-    Events::OnCG_DrawActive(
-        []()
-        {
-            if (is_playing)
-            {
-                static auto bigDevFont = iw4::mp_tu6::R_RegisterFont("fonts/bigDevFont");
-                iw4::mp_tu6::R_AddCmdDrawText("TAS", 4, bigDevFont, 10.f, 20.f, 1.0f, 1.0f, 0.0f, color_white_rgba, 0);
-            }
-        });
 }
 
 MovementRecorder::~MovementRecorder()

--- a/src/game/iw4/mp_tu6/components/mr.h
+++ b/src/game/iw4/mp_tu6/components/mr.h
@@ -11,6 +11,9 @@ class MovementRecorder : public Module
   public:
     MovementRecorder();
     ~MovementRecorder();
+
+    static void OnCGDrawActive();
+    static void OnCmdInit();
     static bool TAS_Enabled();
     static void MovementRecorder::On_CG_Init();
 };

--- a/src/game/iw4/mp_tu6/components/pm.cpp
+++ b/src/game/iw4/mp_tu6/components/pm.cpp
@@ -1,6 +1,5 @@
 #include "pch.h"
 #include "pm.h"
-#include "events.h"
 
 namespace iw4
 {
@@ -33,16 +32,15 @@ gentity_s *Weapon_RocketLauncher_Fire_Hook(gentity_s *ent, unsigned int weaponIn
 
 } // namespace
 
+void pm::OnDvarInit()
+{
+    bg_rocketJump = Dvar_RegisterBool("bg_rocketJump", false, DVAR_FLAG_SERVERINFO, "Enable CoD4 rocket jumps");
+    bg_rocketJumpScale = Dvar_RegisterFloat("bg_rocketJumpScale", 64.0f, 1.0f, FLT_MAX, DVAR_FLAG_SERVERINFO,
+                                            "The scale applied to the pushback force of a rocket");
+}
+
 pm::pm()
 {
-    Events::OnDvarInit(
-        []
-        {
-            bg_rocketJump = Dvar_RegisterBool("bg_rocketJump", false, DVAR_FLAG_SERVERINFO, "Enable CoD4 rocket jumps");
-            bg_rocketJumpScale = Dvar_RegisterFloat("bg_rocketJumpScale", 64.0f, 1.0f, FLT_MAX, DVAR_FLAG_SERVERINFO,
-                                                    "The scale applied to the pushback force of a rocket");
-        });
-
     Weapon_RocketLauncher_Fire_Detour = Detour(Weapon_RocketLauncher_Fire, Weapon_RocketLauncher_Fire_Hook);
     Weapon_RocketLauncher_Fire_Detour.Install();
 }

--- a/src/game/iw4/mp_tu6/components/pm.h
+++ b/src/game/iw4/mp_tu6/components/pm.h
@@ -11,6 +11,8 @@ class pm : public Module
   public:
     pm();
     ~pm();
+
+    static void OnDvarInit();
 };
 } // namespace mp_tu6
 } // namespace iw4

--- a/src/game/iw4/mp_tu6/components/stats.cpp
+++ b/src/game/iw4/mp_tu6/components/stats.cpp
@@ -1,6 +1,5 @@
 #include "pch.h"
 #include <stdlib.h>
-#include "events.h"
 #include "stats.h"
 
 namespace iw4
@@ -98,9 +97,13 @@ void RegisterCommands()
 }
 } // namespace
 
+void stats::OnCmdInit()
+{
+    RegisterCommands();
+}
+
 stats::stats()
 {
-    Events::OnCmdInit(RegisterCommands);
 }
 
 stats::~stats()

--- a/src/game/iw4/mp_tu6/components/stats.h
+++ b/src/game/iw4/mp_tu6/components/stats.h
@@ -11,6 +11,8 @@ class stats : public Module
   public:
     stats();
     ~stats();
+
+    static void OnCmdInit();
 };
 } // namespace mp_tu6
 } // namespace iw4

--- a/src/game/iw4/mp_tu6/components/sv_bots.cpp
+++ b/src/game/iw4/mp_tu6/components/sv_bots.cpp
@@ -1,5 +1,4 @@
 #include "pch.h"
-#include "events.h"
 #include "sv_bots.h"
 
 namespace iw4
@@ -31,6 +30,11 @@ static void CleanBotArray()
 {
     ZeroMemory(&g_botai, sizeof(g_botai));
     s_pendingBotName[0] = '\0';
+}
+
+void SVBots::OnVMShutdown()
+{
+    CleanBotArray();
 }
 
 static char ClampMove(int value)
@@ -356,8 +360,6 @@ void PlayerCmd_BotAngles(scr_entref_t entref)
 
 SVBots::SVBots()
 {
-    Events::OnVMShutdown(CleanBotArray);
-
     G_SelectWeaponIndex_Detour = Detour(G_SelectWeaponIndex, G_SelectWeaponIndex_Hook);
     G_SelectWeaponIndex_Detour.Install();
 

--- a/src/game/iw4/mp_tu6/components/sv_bots.h
+++ b/src/game/iw4/mp_tu6/components/sv_bots.h
@@ -19,6 +19,8 @@ class SVBots : public Module
   public:
     SVBots();
     ~SVBots();
+
+    static void OnVMShutdown();
 };
 } // namespace mp_tu6
 } // namespace iw4

--- a/src/game/iw5/mp/events.cpp
+++ b/src/game/iw5/mp/events.cpp
@@ -1,13 +1,27 @@
 #include "pch.h"
 #include "events.h"
 
+#include "main.h"
+#include "pm.h"
+
 namespace iw5
 {
 namespace mp
 {
+namespace
+{
+typedef void (*EventHandler)();
+typedef void (*VMShutdownHandler)(bool freeScripts);
 
-std::vector<std::function<void()>> Events::com_initdvars_callbacks;
-std::vector<std::function<void(bool)>> Events::vm_shutdown_callbacks;
+const EventHandler dvarInitHandlers[] = {
+    PlayerMovement::OnDvarInit,
+};
+
+const VMShutdownHandler vmShutdownHandlers[] = {
+    IW5_MP_Plugin::OnVMShutdown,
+};
+} // namespace
+
 Detour Events::Com_InitDvars_Detour;
 Detour Events::G_ShutdownGame_Detour;
 
@@ -15,32 +29,21 @@ void Events::Com_InitDvars_Hook()
 {
     Com_InitDvars_Detour.GetOriginal<Com_InitDvars_t>()();
 
-    for (auto it = com_initdvars_callbacks.begin(); it != com_initdvars_callbacks.end(); ++it)
+    for (size_t i = 0; i < ARRAYSIZE(dvarInitHandlers); ++i)
     {
-        (*it)();
+        dvarInitHandlers[i]();
     }
-
-    com_initdvars_callbacks.clear();
 }
 
 void Events::G_ShutdownGame_Hook(int freeScripts)
 {
     G_ShutdownGame_Detour.GetOriginal<G_ShutdownGame_t>()(freeScripts);
 
-    for (auto it = vm_shutdown_callbacks.begin(); it != vm_shutdown_callbacks.end(); ++it)
+    const bool shouldFreeScripts = freeScripts != 0;
+    for (size_t i = 0; i < ARRAYSIZE(vmShutdownHandlers); ++i)
     {
-        (*it)(freeScripts != 0);
+        vmShutdownHandlers[i](shouldFreeScripts);
     }
-}
-
-void Events::OnDvarInit(const std::function<void()> &callback)
-{
-    com_initdvars_callbacks.emplace_back(callback);
-}
-
-void Events::OnVMShutdown(const std::function<void(bool)> &callback)
-{
-    vm_shutdown_callbacks.emplace_back(callback);
 }
 
 Events::Events()
@@ -56,8 +59,6 @@ Events::~Events()
 {
     Com_InitDvars_Detour.Remove();
     G_ShutdownGame_Detour.Remove();
-    com_initdvars_callbacks.clear();
-    vm_shutdown_callbacks.clear();
 }
 
 } // namespace mp

--- a/src/game/iw5/mp/events.h
+++ b/src/game/iw5/mp/events.h
@@ -12,12 +12,7 @@ class Events : public Module
     Events();
     ~Events();
 
-    static void OnDvarInit(const std::function<void()> &callback);
-    static void OnVMShutdown(const std::function<void(bool)> &callback);
-
   private:
-    static std::vector<std::function<void()>> com_initdvars_callbacks;
-    static std::vector<std::function<void(bool)>> vm_shutdown_callbacks;
     static Detour Com_InitDvars_Detour;
     static Detour G_ShutdownGame_Detour;
     static void Com_InitDvars_Hook();

--- a/src/game/iw5/mp/main.cpp
+++ b/src/game/iw5/mp/main.cpp
@@ -64,6 +64,11 @@ void ResetLoadedScripts(bool freeScripts)
     g_gsc_bytecode_arena_used = 0;
 }
 
+void IW5_MP_Plugin::OnVMShutdown(bool freeScripts)
+{
+    ResetLoadedScripts(freeScripts);
+}
+
 /**
  * GSC Tool binary file format.
  * https://github.com/xensik/gsc-tool?tab=readme-ov-file#file-format
@@ -206,8 +211,6 @@ IW5_MP_Plugin::IW5_MP_Plugin()
 
     DB_IsXAssetDefault_Detour = Detour(DB_IsXAssetDefault, DB_IsXAssetDefault_Hook);
     DB_IsXAssetDefault_Detour.Install();
-
-    Events::OnVMShutdown(ResetLoadedScripts);
 }
 
 IW5_MP_Plugin::~IW5_MP_Plugin()

--- a/src/game/iw5/mp/main.h
+++ b/src/game/iw5/mp/main.h
@@ -12,6 +12,8 @@ class IW5_MP_Plugin : public Plugin
   public:
     IW5_MP_Plugin();
     ~IW5_MP_Plugin();
+
+    static void OnVMShutdown(bool freeScripts);
 };
 } // namespace mp
 } // namespace iw5

--- a/src/game/iw5/mp/pm.cpp
+++ b/src/game/iw5/mp/pm.cpp
@@ -1,6 +1,5 @@
 #include "pch.h"
 #include "pm.h"
-#include "events.h"
 
 namespace iw5
 {
@@ -34,17 +33,16 @@ gentity_s *Weapon_RocketLauncher_Fire_Hook(gentity_s *ent, const Weapon *weapon,
 }
 } // namespace
 
+void PlayerMovement::OnDvarInit()
+{
+    bg_rocketJump = Dvar_RegisterBool("bg_rocketJump", false, DVAR_FLAG_SERVERINFO, "Enable CoD4 rocket jumps");
+
+    bg_rocketJumpScale = Dvar_RegisterFloat("bg_rocketJumpScale", 64.0f, 1.0f, FLT_MAX, DVAR_FLAG_SERVERINFO,
+                                            "The scale applied to the pushback force of a rocket");
+}
+
 PlayerMovement::PlayerMovement()
 {
-    Events::OnDvarInit(
-        []
-        {
-            bg_rocketJump = Dvar_RegisterBool("bg_rocketJump", false, DVAR_FLAG_SERVERINFO, "Enable CoD4 rocket jumps");
-
-            bg_rocketJumpScale = Dvar_RegisterFloat("bg_rocketJumpScale", 64.0f, 1.0f, FLT_MAX, DVAR_FLAG_SERVERINFO,
-                                                    "The scale applied to the pushback force of a rocket");
-        });
-
     Weapon_RocketLauncher_Fire_Detour = Detour(Weapon_RocketLauncher_Fire, Weapon_RocketLauncher_Fire_Hook);
     Weapon_RocketLauncher_Fire_Detour.Install();
 }

--- a/src/game/iw5/mp/pm.h
+++ b/src/game/iw5/mp/pm.h
@@ -11,6 +11,8 @@ class PlayerMovement : public Module
   public:
     PlayerMovement();
     ~PlayerMovement();
+
+    static void OnDvarInit();
 };
 } // namespace mp
 } // namespace iw5

--- a/src/game/qos/mp/components/clipmap.cpp
+++ b/src/game/qos/mp/components/clipmap.cpp
@@ -1,6 +1,5 @@
 #include "pch.h"
 #include "common/brush_collision_tracker.h"
-#include "events.h"
 #include "clipmap.h"
 
 static const int SURFACE_FLAG_PLAYERCLIP = 0x10000;
@@ -153,24 +152,22 @@ void clipmap::PlayerCmd_DisablePlayerClipOnTouchingBrushes(scr_entref_t entref)
     RebuildNoclipBrushesDvar();
 }
 
+void clipmap::OnCGInit()
+{
+    RegisterDvars();
+    brush_collision_tracker::Clear();
+}
+
+void clipmap::OnCGDrawActive()
+{
+    if (R_CheckDvarModified(noclip_brushes))
+    {
+        HandleclipmapChange();
+    }
+}
+
 clipmap::clipmap()
 {
-
-    Events::OnCG_Init(
-        []()
-        {
-            clipmap::RegisterDvars();
-            brush_collision_tracker::Clear();
-        });
-
-    Events::OnCG_DrawActive(
-        []()
-        {
-            if (R_CheckDvarModified(clipmap::noclip_brushes))
-            {
-                HandleclipmapChange();
-            }
-        });
 }
 
 clipmap::~clipmap()

--- a/src/game/qos/mp/components/clipmap.h
+++ b/src/game/qos/mp/components/clipmap.h
@@ -12,6 +12,8 @@ class clipmap : public Module
     clipmap();
     ~clipmap();
 
+    static void OnCGDrawActive();
+    static void OnCGInit();
     static void PlayerCmd_DisablePlayerClipOnTouchingBrushes(scr_entref_t entref);
 
   private:

--- a/src/game/qos/mp/components/events.cpp
+++ b/src/game/qos/mp/components/events.cpp
@@ -1,70 +1,50 @@
 #include "pch.h"
 #include "events.h"
 
+#include "clipmap.h"
+
 namespace qos
 {
 namespace mp
 {
+namespace
+{
+typedef void (*EventHandler)();
 
-std::vector<std::function<void()>> Events::cg_drawactive_callbacks;
+const EventHandler cgDrawActiveHandlers[] = {
+    clipmap::OnCGDrawActive,
+};
+
+const EventHandler cgInitHandlers[] = {
+    clipmap::OnCGInit,
+};
+} // namespace
 
 void Events::CG_DrawActive_Hook(int localClientNum)
 {
     // Call original function first
     CG_DrawActive_Detour.GetOriginal<decltype(&CG_DrawActive_Hook)>()(localClientNum);
 
-    for (auto it = cg_drawactive_callbacks.begin(); it != cg_drawactive_callbacks.end(); ++it)
+    for (size_t i = 0; i < ARRAYSIZE(cgDrawActiveHandlers); ++i)
     {
-        (*it)();
+        cgDrawActiveHandlers[i]();
     }
 }
 
-void Events::OnCG_DrawActive(const std::function<void()> &callback)
-{
-    cg_drawactive_callbacks.emplace_back(callback);
-}
-
 Detour Events::CG_DrawActive_Detour;
-
-std::vector<std::function<void()>> Events::cg_init_callbacks;
 
 void Events::CG_Init_Hook(int localClientNum, int serverMessageNum, int serverCommandSequence, int clientNum)
 {
     // Call original function first
     CG_Init_Detour.GetOriginal<CG_Init_t>()(localClientNum, serverMessageNum, serverCommandSequence, clientNum);
 
-    for (auto it = cg_init_callbacks.begin(); it != cg_init_callbacks.end(); ++it)
+    for (size_t i = 0; i < ARRAYSIZE(cgInitHandlers); ++i)
     {
-        (*it)();
+        cgInitHandlers[i]();
     }
-}
-
-void Events::OnCG_Init(const std::function<void()> &callback)
-{
-    cg_init_callbacks.emplace_back(callback);
 }
 
 Detour Events::CG_Init_Detour;
-
-std::vector<std::function<void()>> Events::vmshutdown_callbacks;
-
-void Events::Scr_ShutdownSystem_Hook(unsigned __int8 sys, int bComplete)
-{
-    for (auto it = vmshutdown_callbacks.begin(); it != vmshutdown_callbacks.end(); ++it)
-    {
-        (*it)();
-    }
-
-    // Call original function after callbacks
-    Scr_ShutdownSystem_Detour.GetOriginal<Scr_ShutdownSystem_t>()(sys, bComplete);
-}
-
-void Events::OnVMShutdown(const std::function<void()> &callback)
-{
-    vmshutdown_callbacks.emplace_back(callback);
-}
-
-Detour Events::Scr_ShutdownSystem_Detour;
 
 Events::Events()
 {
@@ -73,20 +53,12 @@ Events::Events()
 
     CG_Init_Detour = Detour(CG_Init, CG_Init_Hook);
     CG_Init_Detour.Install();
-
-    Scr_ShutdownSystem_Detour = Detour(Scr_ShutdownSystem, Scr_ShutdownSystem_Hook);
-    Scr_ShutdownSystem_Detour.Install();
 }
 
 Events::~Events()
 {
     CG_DrawActive_Detour.Remove();
     CG_Init_Detour.Remove();
-    Scr_ShutdownSystem_Detour.Remove();
-
-    cg_drawactive_callbacks.clear();
-    cg_init_callbacks.clear();
-    vmshutdown_callbacks.clear();
 }
 
 } // namespace mp

--- a/src/game/qos/mp/components/events.h
+++ b/src/game/qos/mp/components/events.h
@@ -13,22 +13,12 @@ class Events : public Module
     Events();
     ~Events();
 
-    static void OnCG_DrawActive(const std::function<void()> &callback);
-    static void OnCG_Init(const std::function<void()> &callback);
-    static void OnVMShutdown(const std::function<void()> &callback);
-
   private:
-    static std::vector<std::function<void()>> cg_drawactive_callbacks;
     static Detour CG_DrawActive_Detour;
     static void CG_DrawActive_Hook(int localClientNum);
 
-    static std::vector<std::function<void()>> cg_init_callbacks;
     static Detour CG_Init_Detour;
     static void CG_Init_Hook(int localClientNum, int serverMessageNum, int serverCommandSequence, int clientNum);
-
-    static std::vector<std::function<void()>> vmshutdown_callbacks;
-    static Detour Scr_ShutdownSystem_Detour;
-    static void Scr_ShutdownSystem_Hook(unsigned __int8 sys, int bComplete);
 };
 } // namespace mp
 } // namespace qos

--- a/src/game/t4/mp/components/brush_collision.cpp
+++ b/src/game/t4/mp/components/brush_collision.cpp
@@ -1,7 +1,6 @@
 #include "pch.h"
 #include "common/brush_collision_tracker.h"
 #include "brush_collision.h"
-#include "events.h"
 
 namespace t4
 {
@@ -119,15 +118,14 @@ void CG_DrawActive_Hook(int localClientNum)
     CG_DrawActive_Detour.GetOriginal<decltype(CG_DrawActive)>()(localClientNum);
 }
 
+void BrushCollision::OnDvarInit()
+{
+    noclip_brushes = Dvar_RegisterString("noclip_brushes", "", DVAR_CODINFO,
+                                         "Space separated list of brushes to disable collision on.");
+}
+
 BrushCollision::BrushCollision()
 {
-    Events::OnDvarInit(
-        []
-        {
-            noclip_brushes = Dvar_RegisterString("noclip_brushes", "", DVAR_CODINFO,
-                                                 "Space separated list of brushes to disable collision on.");
-        });
-
     CG_DrawActive_Detour = Detour(CG_DrawActive, CG_DrawActive_Hook);
     CG_DrawActive_Detour.Install();
 

--- a/src/game/t4/mp/components/brush_collision.h
+++ b/src/game/t4/mp/components/brush_collision.h
@@ -11,6 +11,8 @@ class BrushCollision : public Module
   public:
     BrushCollision();
     ~BrushCollision();
+
+    static void OnDvarInit();
 };
 } // namespace mp
 } // namespace t4

--- a/src/game/t4/mp/components/console.cpp
+++ b/src/game/t4/mp/components/console.cpp
@@ -1,6 +1,5 @@
 #include "pch.h"
 #include "console.h"
-#include "events.h"
 
 namespace t4
 {
@@ -296,8 +295,6 @@ void CL_WritePacket_Hook(int localClientNum)
 
 console::console()
 {
-    Events::OnUIRefresh(console::frame);
-
     CL_WritePacket_Detour = Detour(CL_WritePacket, CL_WritePacket_Hook);
     CL_WritePacket_Detour.Install();
 }
@@ -305,6 +302,11 @@ console::console()
 console::~console()
 {
     CL_WritePacket_Detour.Remove();
+}
+
+void console::OnUIRefresh()
+{
+    frame();
 }
 
 void console::frame()

--- a/src/game/t4/mp/components/console.h
+++ b/src/game/t4/mp/components/console.h
@@ -13,6 +13,7 @@ class console : public Module
     console();
     ~console();
 
+    static void OnUIRefresh();
     static void frame();
     static void toggle();
     static void close();

--- a/src/game/t4/mp/components/events.cpp
+++ b/src/game/t4/mp/components/events.cpp
@@ -1,31 +1,44 @@
 #include "pch.h"
 #include "events.h"
 
+#include "brush_collision.h"
+#include "console.h"
+#include "stats.h"
+#include "sv_bots.h"
+
 namespace t4
 {
 namespace mp
 {
+namespace
+{
+typedef void (*EventHandler)();
 
-std::vector<std::function<void()>> Events::dvarinit_callbacks;
-std::vector<std::function<void()>> Events::cmdinit_callbacks;
-std::vector<std::function<void()>> Events::vmshutdown_callbacks;
-std::vector<std::function<void()>> Events::ui_refresh_callbacks;
+const EventHandler dvarInitHandlers[] = {
+    BrushCollision::OnDvarInit,
+};
+
+const EventHandler cmdInitHandlers[] = {
+    stats::OnCmdInit,
+};
+
+const EventHandler vmShutdownHandlers[] = {
+    SVBots::OnVMShutdown,
+};
+
+const EventHandler uiRefreshHandlers[] = {
+    console::OnUIRefresh,
+};
+} // namespace
 
 void Events::Com_InitDvars_Hook()
 {
-    for (auto it = dvarinit_callbacks.begin(); it != dvarinit_callbacks.end(); ++it)
+    for (size_t i = 0; i < ARRAYSIZE(dvarInitHandlers); ++i)
     {
-        (*it)();
+        dvarInitHandlers[i]();
     }
 
-    dvarinit_callbacks.clear();
-
     Com_InitDvars_Detour.GetOriginal<decltype(Com_InitDvars)>()();
-}
-
-void Events::OnDvarInit(const std::function<void()> &callback)
-{
-    dvarinit_callbacks.emplace_back(callback);
 }
 
 Detour Events::Com_InitDvars_Detour;
@@ -34,34 +47,22 @@ void Events::Cmd_Init_Hook()
 {
     Cmd_Init_Detour.GetOriginal<Cmd_Init_t>()();
 
-    for (auto it = cmdinit_callbacks.begin(); it != cmdinit_callbacks.end(); ++it)
+    for (size_t i = 0; i < ARRAYSIZE(cmdInitHandlers); ++i)
     {
-        (*it)();
+        cmdInitHandlers[i]();
     }
-
-    cmdinit_callbacks.clear();
-}
-
-void Events::OnCmdInit(const std::function<void()> &callback)
-{
-    cmdinit_callbacks.emplace_back(callback);
 }
 
 Detour Events::Cmd_Init_Detour;
 
 void *Events::Scr_ShutdownSystem_Hook(scriptInstance_t inst, int sys, int bComplete)
 {
-    for (auto it = vmshutdown_callbacks.begin(); it != vmshutdown_callbacks.end(); ++it)
+    for (size_t i = 0; i < ARRAYSIZE(vmShutdownHandlers); ++i)
     {
-        (*it)();
+        vmShutdownHandlers[i]();
     }
 
     return Scr_ShutdownSystem_Detour.GetOriginal<Scr_ShutdownSystem_t>()(inst, sys, bComplete);
-}
-
-void Events::OnVMShutdown(const std::function<void()> &callback)
-{
-    vmshutdown_callbacks.emplace_back(callback);
 }
 
 Detour Events::Scr_ShutdownSystem_Detour;
@@ -70,17 +71,12 @@ int Events::UI_Refresh_Hook(int localClientNum)
 {
     const int result = UI_Refresh_Detour.GetOriginal<UI_Refresh_t>()(localClientNum);
 
-    for (auto it = ui_refresh_callbacks.begin(); it != ui_refresh_callbacks.end(); ++it)
+    for (size_t i = 0; i < ARRAYSIZE(uiRefreshHandlers); ++i)
     {
-        (*it)();
+        uiRefreshHandlers[i]();
     }
 
     return result;
-}
-
-void Events::OnUIRefresh(const std::function<void()> &callback)
-{
-    ui_refresh_callbacks.emplace_back(callback);
 }
 
 Detour Events::UI_Refresh_Detour;
@@ -106,11 +102,6 @@ Events::~Events()
     Cmd_Init_Detour.Remove();
     Scr_ShutdownSystem_Detour.Remove();
     UI_Refresh_Detour.Remove();
-
-    dvarinit_callbacks.clear();
-    cmdinit_callbacks.clear();
-    vmshutdown_callbacks.clear();
-    ui_refresh_callbacks.clear();
 }
 
 } // namespace mp

--- a/src/game/t4/mp/components/events.h
+++ b/src/game/t4/mp/components/events.h
@@ -12,25 +12,16 @@ class Events : public Module
     Events();
     ~Events();
 
-    static void OnDvarInit(const std::function<void()> &callback);
-    static void OnCmdInit(const std::function<void()> &callback);
-    static void OnVMShutdown(const std::function<void()> &callback);
-    static void OnUIRefresh(const std::function<void()> &callback);
-
   private:
-    static std::vector<std::function<void()>> dvarinit_callbacks;
     static Detour Com_InitDvars_Detour;
     static void Com_InitDvars_Hook();
 
-    static std::vector<std::function<void()>> cmdinit_callbacks;
     static Detour Cmd_Init_Detour;
     static void Cmd_Init_Hook();
 
-    static std::vector<std::function<void()>> vmshutdown_callbacks;
     static Detour Scr_ShutdownSystem_Detour;
     static void *Scr_ShutdownSystem_Hook(scriptInstance_t inst, int sys, int bComplete);
 
-    static std::vector<std::function<void()>> ui_refresh_callbacks;
     static Detour UI_Refresh_Detour;
     static int UI_Refresh_Hook(int localClientNum);
 };

--- a/src/game/t4/mp/components/stats.cpp
+++ b/src/game/t4/mp/components/stats.cpp
@@ -1,5 +1,4 @@
 #include "pch.h"
-#include "events.h"
 #include "stats.h"
 
 namespace t4
@@ -225,9 +224,13 @@ void RegisterCommands()
 }
 } // namespace
 
+void stats::OnCmdInit()
+{
+    RegisterCommands();
+}
+
 stats::stats()
 {
-    Events::OnCmdInit(RegisterCommands);
 }
 
 stats::~stats()

--- a/src/game/t4/mp/components/stats.h
+++ b/src/game/t4/mp/components/stats.h
@@ -11,6 +11,8 @@ class stats : public Module
   public:
     stats();
     ~stats();
+
+    static void OnCmdInit();
 };
 } // namespace mp
 } // namespace t4

--- a/src/game/t4/mp/components/sv_bots.cpp
+++ b/src/game/t4/mp/components/sv_bots.cpp
@@ -1,5 +1,4 @@
 #include "pch.h"
-#include "events.h"
 #include "sv_bots.h"
 
 namespace t4
@@ -26,6 +25,11 @@ static char s_pendingBotName[32];
 static void CleanBotArray()
 {
     ZeroMemory(&g_botai, sizeof(g_botai));
+}
+
+void SVBots::OnVMShutdown()
+{
+    CleanBotArray();
 }
 
 static gentity_s *GetPlayerEntity(scr_entref_t entref)
@@ -277,8 +281,6 @@ void PlayerCmd_IsHost(scr_entref_t entref)
 
 SVBots::SVBots()
 {
-    Events::OnVMShutdown(CleanBotArray);
-
     G_SelectWeaponIndex_Detour = Detour(G_SelectWeaponIndex, G_SelectWeaponIndex_Hook);
     G_SelectWeaponIndex_Detour.Install();
 

--- a/src/game/t4/mp/components/sv_bots.h
+++ b/src/game/t4/mp/components/sv_bots.h
@@ -11,6 +11,8 @@ class SVBots : public Module
   public:
     SVBots();
     ~SVBots();
+
+    static void OnVMShutdown();
 };
 
 void PlayerCmd_BotAction(scr_entref_t entref);


### PR DESCRIPTION
This reduces churn on the heap which seems to be troublesome in the context of a long lived plugin that survives title changes.