### PR TITLE
fix(iw3): allocate map ents overrides from game hunk

### DIFF
--- a/src/game/iw3/mp/components/assets.cpp
+++ b/src/game/iw3/mp/components/assets.cpp
@@ -7,6 +7,32 @@ namespace mp
 {
 namespace
 {
+bool BuildMapEntsPath(char *path, size_t pathSize, const char *mapEntsName)
+{
+    if (!path || pathSize == 0 || !mapEntsName || mapEntsName[0] == '\0')
+    {
+        return false;
+    }
+
+    const int written = _snprintf_s(path, pathSize, _TRUNCATE, "%s\\%s.ents", Config::GetModBasePath(), mapEntsName);
+    path[pathSize - 1] = '\0';
+
+    if (written < 0 || static_cast<size_t>(written) >= pathSize)
+    {
+        return false;
+    }
+
+    for (char *cursor = path; *cursor != '\0'; ++cursor)
+    {
+        if (*cursor == '/')
+        {
+            *cursor = '\\';
+        }
+    }
+
+    return true;
+}
+
 void OverrideMapEnts(MapEnts *mapEnts)
 {
     if (!mapEnts || !mapEnts->name || mapEnts->name[0] == ',')
@@ -14,42 +40,60 @@ void OverrideMapEnts(MapEnts *mapEnts)
         return;
     }
 
-    std::string filePath = Config::GetModBasePath();
-    filePath += std::string("\\") + mapEnts->name + ".ents";
-    std::replace(filePath.begin(), filePath.end(), '/', '\\');
-
-    if (!filesystem::file_exists(filePath))
+    char filePath[MAX_PATH];
+    if (!BuildMapEntsPath(filePath, sizeof(filePath), mapEnts->name))
     {
         return;
     }
 
-    const std::string entityString = filesystem::read_file_to_string(filePath);
-    if (entityString.empty())
+    HANDLE file = CreateFileA(filePath, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING,
+                              FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (file == INVALID_HANDLE_VALUE)
     {
         return;
     }
 
-    const size_t bufferSize = entityString.size() + 1;
-    char *buffer = static_cast<char *>(malloc(bufferSize));
+    const DWORD fileSize = GetFileSize(file, nullptr);
+    if (fileSize == INVALID_FILE_SIZE || fileSize == 0 || fileSize > INT_MAX)
+    {
+        CloseHandle(file);
+        return;
+    }
+
+    char *buffer = static_cast<char *>(Hunk_AllocAlignInternal(fileSize + 1, 1));
     if (!buffer)
     {
+        CloseHandle(file);
         Com_PrintError(CON_CHANNEL_ERROR, "Failed to allocate MapEnts override for '%s'\n", mapEnts->name);
         return;
     }
 
-    memcpy(buffer, entityString.c_str(), bufferSize);
+    DWORD bytesRead = 0;
+    if (!ReadFile(file, buffer, fileSize, &bytesRead, nullptr) || bytesRead != fileSize)
+    {
+        CloseHandle(file);
+        Com_PrintError(CON_CHANNEL_ERROR, "Failed to read MapEnts override for '%s'\n", mapEnts->name);
+        return;
+    }
+
+    CloseHandle(file);
+    buffer[fileSize] = '\0';
+
     mapEnts->entityString = buffer;
+    mapEnts->numEntityChars = static_cast<int>(fileSize);
+
+    DbgPrint("[codxe][iw3] Loaded MapEnts override: %s (%u bytes at %p).\n", filePath, fileSize, buffer);
 }
 } // namespace
 
 void assets::OnAssetLink(XAsset *asset)
 {
-    if (asset->type != ASSET_TYPE_MAP_ENTS)
+    switch (asset->type)
     {
-        return;
+    case ASSET_TYPE_MAP_ENTS:
+        OverrideMapEnts(asset->header.mapEnts);
+        break;
     }
-
-    OverrideMapEnts(asset->header.mapEnts);
 }
 } // namespace mp
 } // namespace iw3

--- a/src/game/iw3/mp/symbols.h
+++ b/src/game/iw3/mp/symbols.h
@@ -253,6 +253,9 @@ static auto CL_SetStance = reinterpret_cast<void (*)(int localClientNum, int sta
 typedef void (*CG_Init_t)(int localClientNum, int serverMessageNum, int serverCommandSequence, int clientNum);
 static CG_Init_t CG_Init = reinterpret_cast<CG_Init_t>(0x8230DEA0);
 
+typedef void *(*Hunk_AllocAlignInternal_t)(size_t size, int alignment);
+static Hunk_AllocAlignInternal_t Hunk_AllocAlignInternal =
+    reinterpret_cast<Hunk_AllocAlignInternal_t>(0x821D7438);
 static auto Hunk_AllocateTempMemoryHighInternal = reinterpret_cast<void *(*)(int size)>(0x821D7328);
 static auto Scr_AddSourceBuffer =
     reinterpret_cast<char *(*)(const char *filename, const char *extFilename, const char *codePos, bool archive)>(

--- a/src/game/iw3/mp/symbols.h
+++ b/src/game/iw3/mp/symbols.h
@@ -254,8 +254,7 @@ typedef void (*CG_Init_t)(int localClientNum, int serverMessageNum, int serverCo
 static CG_Init_t CG_Init = reinterpret_cast<CG_Init_t>(0x8230DEA0);
 
 typedef void *(*Hunk_AllocAlignInternal_t)(size_t size, int alignment);
-static Hunk_AllocAlignInternal_t Hunk_AllocAlignInternal =
-    reinterpret_cast<Hunk_AllocAlignInternal_t>(0x821D7438);
+static Hunk_AllocAlignInternal_t Hunk_AllocAlignInternal = reinterpret_cast<Hunk_AllocAlignInternal_t>(0x821D7438);
 static auto Hunk_AllocateTempMemoryHighInternal = reinterpret_cast<void *(*)(int size)>(0x821D7328);
 static auto Scr_AddSourceBuffer =
     reinterpret_cast<char *(*)(const char *filename, const char *extFilename, const char *codePos, bool archive)>(


### PR DESCRIPTION
Fixes a crash when changing titles due to heap corruption.