### PR TITLE
fix(xbox360): defer notifications to title threads

### DIFF
--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -130,8 +130,6 @@ bool DllMain(HANDLE hModule, DWORD reason, LPVOID lpvReserved)
             return TRUE;
         }
 
-        xbox::ApplySystemPatches();
-
         ExRegisterTitleTerminateNotification(&g_title_terminate_registration, TRUE);
         g_title_terminate_registered = true;
 

--- a/src/xbox360.cpp
+++ b/src/xbox360.cpp
@@ -20,12 +20,21 @@ enum XNotifyQueueUIType
     XNOTIFYUI_TYPE_EXCLAIM = 34,
 };
 
-typedef int (*XNotifyQueueUI_t)(XNotifyQueueUIType type, DWORD user_index, DWORD areas, const WCHAR *display_text,
-                                void *context_data);
+typedef void (*XNotifyQueueUI_t)(XNotifyQueueUIType type, DWORD user_index, uint64_t areas, const WCHAR *display_text,
+                                 void *context_data);
 static XNotifyQueueUI_t XNotifyQueueUI = reinterpret_cast<XNotifyQueueUI_t>(ResolveFunction("xam.xex", 656));
 
 const DWORD XNOTIFY_USER_INDEX_ANY = 0x000000FF;
-const DWORD XNOTIFY_AREA_SYSTEM = 0x00000001;
+const uint64_t XNOTIFY_AREA_SYSTEM = 0x0000000000000001;
+const DWORD XNOTIFY_DELAY_MS = 1000;
+
+struct Notification
+{
+    volatile LONG inUse;
+    WCHAR displayText[160];
+};
+
+Notification g_notifications[2];
 
 /**
  * Check if we are running in Xenia Canary.
@@ -73,6 +82,17 @@ void CopyAsciiToWide(const char *source, WCHAR *destination, size_t destination_
 
     destination[i] = L'\0';
 }
+
+DWORD WINAPI NotifyThread(void *argument)
+{
+    Notification *notification = static_cast<Notification *>(argument);
+
+    Sleep(XNOTIFY_DELAY_MS);
+    XNotifyQueueUI(XNOTIFYUI_TYPE_EXCLAIM, XNOTIFY_USER_INDEX_ANY, XNOTIFY_AREA_SYSTEM, notification->displayText,
+                   nullptr);
+    InterlockedExchange(&notification->inUse, 0);
+    return 0;
+}
 } // namespace
 
 Environment GetEnvironment()
@@ -97,22 +117,41 @@ const char *GetEnvironmentName(Environment environment)
     }
 }
 
-void ApplySystemPatches()
-{
-    // Allow XNotifyQueueUI to be called from system threads.
-    *(volatile uint16_t *)0x816A3158 = 0x4800;
-}
-
 void Notify(const char *message)
 {
     assert(message != nullptr);
 
+    Notification *notification = nullptr;
+    for (size_t i = 0; i < ARRAYSIZE(g_notifications); i++)
+    {
+        if (InterlockedCompareExchange(&g_notifications[i].inUse, 1, 0) == 0)
+        {
+            notification = &g_notifications[i];
+            break;
+        }
+    }
+
+    if (notification == nullptr)
+    {
+        DbgPrint("[codxe] Notification queue is full.\n");
+        return;
+    }
+
     char branded_message[160];
     _snprintf_s(branded_message, sizeof(branded_message), _TRUNCATE, "CoD Xe: %s", message);
+    CopyAsciiToWide(branded_message, notification->displayText, ARRAYSIZE(notification->displayText));
 
-    WCHAR display_text[160];
-    CopyAsciiToWide(branded_message, display_text, ARRAYSIZE(display_text));
-    XNotifyQueueUI(XNOTIFYUI_TYPE_EXCLAIM, XNOTIFY_USER_INDEX_ANY, XNOTIFY_AREA_SYSTEM, display_text, nullptr);
+    HANDLE thread = nullptr;
+    const NTSTATUS status =
+        ExCreateThread(&thread, 0, nullptr, nullptr, NotifyThread, notification, EX_CREATE_FLAG_TITLE_EXEC);
+    if (!NT_SUCCESS(status))
+    {
+        InterlockedExchange(&notification->inUse, 0);
+        DbgPrint("[codxe] Failed to create notification thread: 0x%08X.\n", status);
+        return;
+    }
+
+    CloseHandle(thread);
 }
 
 } // namespace xbox

--- a/src/xbox360.h
+++ b/src/xbox360.h
@@ -12,7 +12,6 @@ enum Environment
 
 Environment GetEnvironment();
 const char *GetEnvironmentName(Environment environment);
-void ApplySystemPatches();
 void Notify(const char *message);
 
 } // namespace xbox


### PR DESCRIPTION
Remove the retail XAM patch that was incorrectly applied to devkit consoles.